### PR TITLE
Adds minPipelinesVersion field in ResourceVersion Table

### DIFF
--- a/api/cmd/db/migration.go
+++ b/api/cmd/db/migration.go
@@ -43,6 +43,17 @@ func Migrate(api *app.APIConfig) error {
 					return nil
 				},
 			},
+			{
+				ID: "202006091100",
+				Migrate: func(tx *gorm.DB) error {
+					if err := tx.AutoMigrate(
+						&model.ResourceVersion{}).Error; err != nil {
+						log.Error(err)
+						return err
+					}
+					return nil
+				},
+			},
 		})
 
 	migration.InitSchema(func(db *gorm.DB) error {

--- a/api/pkg/db/model/model.go
+++ b/api/pkg/db/model/model.go
@@ -43,12 +43,13 @@ type (
 
 	ResourceVersion struct {
 		gorm.Model
-		Version     string
-		Description string
-		URL         string
-		DisplayName string
-		Resource    Resource
-		ResourceID  uint
+		Version             string
+		Description         string
+		URL                 string
+		DisplayName         string
+		MinPipelinesVersion string
+		Resource            Resource
+		ResourceID          uint
 	}
 
 	ResourceTag struct {


### PR DESCRIPTION
Changes:

This adds a database migration adding a column minPipelineVersionin ResourceVersion table which would tell the minimum pipelines version the resource is compatible with.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>