### PR TITLE
Updates endpoint test to use golden file and run tests serially

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -21,4 +21,5 @@ require (
 	golang.org/x/tools v0.0.0-20200626171337-aa94e735be7f // indirect
 	gopkg.in/gormigrate.v1 v1.6.0
 	gopkg.in/yaml.v2 v2.3.0 // indirect
+	gotest.tools/v3 v3.0.2
 )

--- a/api/go.sum
+++ b/api/go.sum
@@ -301,6 +301,7 @@ golang.org/x/tools v0.0.0-20190420181800-aa740d480789/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190531172133-b3315ee88b7d/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190614205625-5aca471b1d59/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
+golang.org/x/tools v0.0.0-20190624222133-a101b041ded4/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190828213141-aed303cbaa74/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191030232956-1e24073be82c/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
@@ -338,5 +339,7 @@ gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gotest.tools/v3 v3.0.2 h1:kG1BFyqVHuQoVQiR1bWGnfz/fmHvvuiSPIV7rvl360E=
+gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/api/pkg/app/app.go
+++ b/api/pkg/app/app.go
@@ -91,19 +91,18 @@ func (ac *APIConfig) Cleanup() {
 	ac.db.Close()
 }
 
-// FromEnv returns a APIConfig object consisting of db and logger.
-// Loads a .env.dev file in development mode
-// Looks for EnvMode and initialises instance of sugared Logger
-// Looks for database configuration among environment variables and connects to db
+// FromEnv is called while initailising the api service, it calls FromEnvFile 
+// passing .env.dev file which will have configuration while running in  
+// development mode 
 func FromEnv() (*APIConfig, error) {
 	// load from .env.dev file for development but skip if not found
 	return FromEnvFile(".env.dev")
 }
 
-// FromEnv returns a APIConfig object consisting of db and logger.
-// Loads a .env.dev file in development mode
-// Looks for EnvMode and initialises instance of sugared Logger
-// Looks for database configuration among environment variables and connects to db
+// FromEnvFile expects a filepath to env file which has db configurations
+// It loads .env file, initialises a db connection & logger depending on the EnvMode
+// and returns a APIConfig Object 
+// If it doesn't finds a .env file, it looks for configuratin among environment variables
 func FromEnvFile(file string) (*APIConfig, error) {
 	if err := godotenv.Load(file); err != nil {
 		fmt.Fprintf(os.Stderr, "SKIP: loading env file %s failed: %s\n", file, err)

--- a/api/pkg/service/category/category.go
+++ b/api/pkg/service/category/category.go
@@ -29,7 +29,11 @@ func New(api app.Config) category.Service {
 // List all categories along with their tags sorted by name
 func (s *service) List(ctx context.Context) (res []*category.Category, err error) {
 	var all []model.Category
-	if err := s.db.Order("name").Preload("Tags").Find(&all).Error; err != nil {
+	if err := s.db.Order("name").
+		Preload("Tags", func(db *gorm.DB) *gorm.DB {
+			return db.Order("tags.name ASC")
+		}).
+		Find(&all).Error; err != nil {
 		s.logger.Error(err)
 		return nil, fetchError
 	}

--- a/api/pkg/service/category/category_http_test.go
+++ b/api/pkg/service/category/category_http_test.go
@@ -1,13 +1,15 @@
 package category
 
 import (
-	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"testing"
 
 	"github.com/ikawaha/goahttpcheck"
 	"github.com/stretchr/testify/assert"
+	"gotest.tools/v3/golden"
+
 	category "github.com/tektoncd/hub/api/gen/category"
 	server "github.com/tektoncd/hub/api/gen/http/category/server"
 	"github.com/tektoncd/hub/api/pkg/testutils"
@@ -29,11 +31,9 @@ func TestCategories_List_Http(t *testing.T) {
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
-		var jsonMap []map[string]interface{}
-		marshallErr := json.Unmarshal([]byte(b), &jsonMap)
-		assert.NoError(t, marshallErr)
+		res, err := testutils.FormatJSON(b)
+		assert.NoError(t, err)
 
-		assert.Equal(t, 3, len(jsonMap))
-		assert.Equal(t, "abc", jsonMap[0]["name"])
+		golden.Assert(t, res, fmt.Sprintf("%s.golden", t.Name()))
 	})
 }

--- a/api/pkg/service/category/category_test.go
+++ b/api/pkg/service/category/category_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"github.com/tektoncd/hub/api/pkg/testutils"
 )
 
@@ -18,5 +19,6 @@ func TestCategory_List(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 3, len(all))
 	assert.Equal(t, 2, len(all[0].Tags))
-	assert.Equal(t, "abc", all[0].Name) // categories are sorted by name
+	assert.Equal(t, "abc", all[0].Name)          // categories are sorted by name
+	assert.Equal(t, "atag", all[0].Tags[0].Name) // tags are sorted by name
 }

--- a/api/pkg/service/category/testdata/TestCategories_List_Http.golden
+++ b/api/pkg/service/category/testdata/TestCategories_List_Http.golden
@@ -1,0 +1,36 @@
+[
+	{
+		"id": 2,
+		"name": "abc",
+		"tags": [
+			{
+				"id": 4,
+				"name": "atag"
+			},
+			{
+				"id": 2,
+				"name": "rtag"
+			}
+		]
+	},
+	{
+		"id": 3,
+		"name": "pqr",
+		"tags": [
+			{
+				"id": 3,
+				"name": "ptag"
+			}
+		]
+	},
+	{
+		"id": 1,
+		"name": "xyz",
+		"tags": [
+			{
+				"id": 1,
+				"name": "ztag"
+			}
+		]
+	}
+]

--- a/api/pkg/testutils/config.go
+++ b/api/pkg/testutils/config.go
@@ -10,6 +10,11 @@ import (
 	"github.com/tektoncd/hub/api/pkg/app"
 )
 
+// TestConfig defines configurations required for running tests
+// APIConfig contains the db object and logger
+// fixturePath is the path to fixture directory which contains test data
+// configPath is the path to test config file
+// err will have error if occured during initialising the test db connection
 type TestConfig struct {
 	*app.APIConfig
 	fixturePath string
@@ -22,7 +27,7 @@ var _ app.Config = (*TestConfig)(nil)
 var once sync.Once
 var tc *TestConfig
 
-// config creates the test configuration once and returns the
+// Config creates the test configuration once and returns the
 // same every time the function is called
 func Config() *TestConfig {
 	once.Do(func() {
@@ -31,22 +36,28 @@ func Config() *TestConfig {
 	return tc
 }
 
+// Path return the file path to test config
 func (tc *TestConfig) Path() string {
 	return tc.configPath
 }
 
+// FixturePath return the directory path to fixtures
 func (tc *TestConfig) FixturePath() string {
 	return tc.fixturePath
 }
 
+// IsValid checks if connection to test db is valid or not
 func (tc *TestConfig) IsValid() bool {
 	return tc.APIConfig != nil && tc.err == nil
 }
 
+// Error returns error if occured during initialising connection to test db
 func (tc *TestConfig) Error() error {
 	return tc.err
 }
 
+// initializeConfig compute the path to test config and fixture directory
+// then initiate the test db connection and returns a TestConfig Object
 func initializeConfig() *TestConfig {
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {

--- a/api/pkg/testutils/db.go
+++ b/api/pkg/testutils/db.go
@@ -9,6 +9,8 @@ import (
 	"github.com/tektoncd/hub/api/pkg/db/model"
 )
 
+// LoadFixtures is called before executing each test, it clears db and
+// loads data from fixtures so that each test is executed on new db
 func LoadFixtures(t *testing.T, dir string) {
 	tc := Config()
 	fixtures, err := testfixtures.New(
@@ -19,6 +21,7 @@ func LoadFixtures(t *testing.T, dir string) {
 	assert.NoError(t, fixtures.Load())
 }
 
+// applyMigration creates tables in test db
 func applyMigration() error {
 	tc := Config()
 	db := tc.DB()

--- a/api/pkg/testutils/run.go
+++ b/api/pkg/testutils/run.go
@@ -7,6 +7,9 @@ import (
 
 var setup sync.Once
 
+// Setup when called first time will connect to test db, run migration to create tables
+// and return TestConfig configurations. After that each time it is called it just retuns
+// TestConfig configurations
 func Setup(t *testing.T) *TestConfig {
 	tc := Config()
 	setup.Do(func() {

--- a/api/pkg/testutils/utils.go
+++ b/api/pkg/testutils/utils.go
@@ -1,0 +1,16 @@
+package testutils
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// FormatJSON formats json string to be added to golden file
+func FormatJSON(b []byte) (string, error) {
+	var formatted bytes.Buffer
+	err := json.Indent(&formatted, b, "", "\t")
+	if err != nil {
+		return "", err
+	}
+	return string(formatted.Bytes()), nil
+}

--- a/api/test/fixtures/categories.yaml
+++ b/api/test/fixtures/categories.yaml
@@ -1,12 +1,12 @@
 - id: 1
   name: xyz
-  created_at: 2016-01-01 12:30:12
-  updated_at: 2016-01-01 12:30:12
+  created_at: 2016-01-01 12:30:12 UTC
+  updated_at: 2016-01-01 12:30:12 UTC
 - id: 2
   name: abc
-  created_at: 2016-01-01 12:30:12
-  updated_at: 2016-01-01 12:30:12
+  created_at: 2016-01-01 12:30:12 UTC
+  updated_at: 2016-01-01 12:30:12 UTC
 - id: 3
   name: pqr
-  created_at: 2016-01-01 12:30:12
-  updated_at: 2016-01-01 12:30:12
+  created_at: 2016-01-01 12:30:12 UTC
+  updated_at: 2016-01-01 12:30:12 UTC

--- a/api/test/fixtures/tags.yaml
+++ b/api/test/fixtures/tags.yaml
@@ -1,20 +1,20 @@
 - id: 1
-  name: tag1
+  name: ztag
   category_id: 1
-  created_at: 2016-01-01 12:30:12
-  updated_at: 2016-01-01 12:30:12
+  created_at: 2016-01-01 12:30:12 UTC
+  updated_at: 2016-01-01 12:30:12 UTC
 - id: 2
-  name: tag2
+  name: rtag
   category_id: 2
-  created_at: 2016-01-01 12:30:12
-  updated_at: 2016-01-01 12:30:12
+  created_at: 2016-01-01 12:30:12 UTC
+  updated_at: 2016-01-01 12:30:12 UTC
 - id: 3
-  name: tag3
+  name: ptag
   category_id: 3
-  created_at: 2016-01-01 12:30:12
-  updated_at: 2016-01-01 12:30:12
+  created_at: 2016-01-01 12:30:12 UTC
+  updated_at: 2016-01-01 12:30:12 UTC
 - id: 4
-  name: tag4
+  name: atag
   category_id: 2
-  created_at: 2016-01-01 12:30:12
-  updated_at: 2016-01-01 12:30:12
+  created_at: 2016-01-01 12:30:12 UTC
+  updated_at: 2016-01-01 12:30:12 UTC

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -69,7 +69,7 @@ api-unittest(){
   info Running unittests
 
   go mod vendor
-  go test -v ./pkg/...
+  go test -p 1 -v ./pkg/...
 }
 
 api-build(){


### PR DESCRIPTION
This updates the /categories API to fetch tags sorted by name.
Updates the endpoint/HTTP test to use golden files to verify
the outcomes.
Also, Updates the CI script to run test serially.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>