### PR TITLE
 Add Org Column & drops Owner column from Catalog Table

### DIFF
--- a/api/pkg/app/data.go
+++ b/api/pkg/app/data.go
@@ -33,9 +33,9 @@ type Category struct {
 
 type Catalog struct {
 	Name       string
+	Org        string
 	Type       string
 	URL        string
-	Owner      string
 	ContextDir string
 	Revision   string
 }

--- a/api/pkg/db/initializer/initiailizer.go
+++ b/api/pkg/db/initializer/initiailizer.go
@@ -79,13 +79,13 @@ func (i *Initializer) addCatalogs() error {
 	for _, c := range i.data.Catalogs {
 		cat := &model.Catalog{
 			Name:       c.Name,
+			Org:        c.Org,
 			Type:       c.Type,
 			URL:        c.URL,
-			Owner:      c.Owner,
 			Revision:   c.Revision,
 			ContextDir: c.ContextDir,
 		}
-		if err := db.Where(&model.Catalog{Name: c.Name, Type: c.Type}).
+		if err := db.Where(&model.Catalog{Name: c.Name, Org: c.Org}).
 			FirstOrCreate(cat).
 			Error; err != nil {
 			i.log.Error(err)

--- a/api/pkg/db/model/model.go
+++ b/api/pkg/db/model/model.go
@@ -35,13 +35,13 @@ type (
 
 	Catalog struct {
 		gorm.Model
-		Name       string
-		Type       string
-		URL        string
-		Owner      string
+		Name       string `gorm:"unique_index:uix_name_org"`
+		Org        string `gorm:"unique_index:uix_name_org"`
+		Type       string `gorm:"not null;default:null"`
+		URL        string `gorm:"not null;default:null"`
+		Revision   string `gorm:"not null;default:null"`
 		ContextDir string
 		Resources  []Resource
-		Revision   string
 	}
 
 	Resource struct {

--- a/api/test/fixtures/catalogs.yaml
+++ b/api/test/fixtures/catalogs.yaml
@@ -13,20 +13,20 @@
 # limitations under the License.
 
 - id: 1
-  name: Tekton
+  name: catalog-official
+  org: tektoncd
   type: official
   url: https:/github.com/tektoncd/catalog
-  owner: tektoncd
   context_dir: /task
   revision: master
   created_at: 2016-01-01 12:30:12 UTC
   updated_at: 2016-01-01 12:30:12 UTC
 
 - id: 2
-  name: Tekton
+  name: catalog-community
+  org: tektoncd
   type: community
   url: https:/github.com/tektoncd/catalog-community
-  owner: tektoncd
   context_dir: /task
   revision: master
   created_at: 2016-01-01 12:30:12 UTC

--- a/config.yaml
+++ b/config.yaml
@@ -31,9 +31,17 @@ categories:
     tags: [test]
 
 catalogs:
-  - name: tektoncd
+  - name: catalog
+    org: tektoncd
     type: community
-    owner: tektoncd
     url: https://github.com/tektoncd/catalog
     revision: master
-    contextDir: /
+
+# Template
+# catalogs:
+#   - name: Name of Catalog
+#     org:  Organization of Catalog
+#     type: Type of Catalog [official, verified, community]
+#     url:  URL of repository
+#     revision: Branch of repository 
+#     contextDir(Optional): Path to resource dir 


### PR DESCRIPTION
# Changes
Adds org column which would be org name of the catalog repo.
Owners will be added later as a array of user who will be authorized
to sync the catalog with Hub.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

