### PR TITLE
Adds users for 'catalog:refresh' scope in config file

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -40,6 +40,8 @@ catalogs:
 scopes:
   - name: agent:create
     users: [pratap0007, puneetpunamiya, sm43, sthaha, vdemeester]
+  - name: catalog:refresh
+    users: [pratap0007, puneetpunamiya, sm43, sthaha, vdemeester]
 
 default:
   scopes:


### PR DESCRIPTION
Adds users who will have access to refresh the catalog.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

