### PR TITLE
Changes default api server mode to production

### DIFF
--- a/api/pkg/app/app.go
+++ b/api/pkg/app/app.go
@@ -271,7 +271,7 @@ func APIBaseFromEnvFile(file string) (*APIBase, error) {
 // It looks for 'ENVIRONMENT' to be defined as environment variable and
 // if does not found it then set it as development mode
 func Environment() EnvMode {
-	mode := "development"
+	mode := "production"
 	if val := viper.GetString("ENVIRONMENT"); val != "" {
 		mode = val
 	}

--- a/api/pkg/app/app.go
+++ b/api/pkg/app/app.go
@@ -116,6 +116,14 @@ func (ab *APIBase) DB() *gorm.DB {
 	return ab.db
 }
 
+// DBWithLogger returns gorm db object initialised with logger
+func DBWithLogger(db *gorm.DB, logger *log.Logger) *gorm.DB {
+	db = db.New()
+	db.SetLogger(&gormLogger{logger})
+	return db
+}
+
+// Database returns the database object used for initializing db connection
 func (ab *APIBase) Database() Database {
 	return *ab.dbConf
 }

--- a/api/pkg/service/catalog/syncer.go
+++ b/api/pkg/service/catalog/syncer.go
@@ -43,9 +43,10 @@ var (
 )
 
 func newSyncer(api app.BaseConfig) *syncer {
+	logger := api.Logger("syncer")
 	return &syncer{
-		db:     api.DB(),
-		logger: api.Logger("syncer").SugaredLogger,
+		db:     app.DBWithLogger(api.DB(), logger),
+		logger: logger.SugaredLogger,
 		limit:  make(chan bool, 1),
 		stop:   make(chan bool),
 		git:    git.New(api.Logger("git").SugaredLogger),


### PR DESCRIPTION
The logger is set on the basis of env mode. so by default, the mode is set
to production.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

