### PR TITLE
Cleanup: removes addScopes from migration

### DIFF
--- a/api/pkg/db/migration/migration.go
+++ b/api/pkg/db/migration/migration.go
@@ -94,13 +94,6 @@ func Migrate(api *app.APIBase) error {
 
 		log.Info("Schema initialised successfully !!")
 
-		if err := addScopes(log, db); err != nil {
-			log.Error(err)
-			return err
-		}
-
-		log.Info("Scopes added successfully !!")
-
 		return nil
 	})
 
@@ -123,23 +116,5 @@ func fkey(log *log.Logger, db *gorm.DB, model interface{}, args ...string) error
 			return err
 		}
 	}
-	return nil
-}
-
-func addScopes(log *log.Logger, db *gorm.DB) error {
-
-	scopes := []string{
-		"agent:create",
-		"catalog:refresh",
-	}
-
-	for _, s := range scopes {
-		sc := &model.Scope{Name: s}
-		if err := db.Create(sc).Error; err != nil {
-			log.Error(err)
-			return err
-		}
-	}
-
 	return nil
 }


### PR DESCRIPTION
Currently, if we have to add a new scope, it will be added through
migration but from now on it can be added in config.yaml and if
the scope doesn't exist, it will be created while running the initializer.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

