### PR TITLE
Replaces hardcoded jwt with function to create it with required scopes

### DIFF
--- a/api/pkg/service/admin/admin_http_test.go
+++ b/api/pkg/service/admin/admin_http_test.go
@@ -24,36 +24,13 @@ import (
 
 	"github.com/ikawaha/goahttpcheck"
 	"github.com/stretchr/testify/assert"
-	goa "goa.design/goa/v3/pkg"
-
 	"github.com/tektoncd/hub/api/gen/admin"
 	"github.com/tektoncd/hub/api/gen/http/admin/server"
 	"github.com/tektoncd/hub/api/pkg/db/model"
 	"github.com/tektoncd/hub/api/pkg/service/auth"
 	"github.com/tektoncd/hub/api/pkg/testutils"
+	goa "goa.design/goa/v3/pkg"
 )
-
-// Token for the user with github name "foo-bar" and github login "foo"
-// It has a scope "agent:create" along with default scope
-const validTokenWithAgentCreateScope = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
-	"eyJpZCI6MTEsImxvZ2luIjoiZm9vIiwibmFtZSI6ImZvby1iYXIiLCJzY29wZXMiOlsicmF0aW5nOnJlYWQiLCJyYXRpbmc6d3JpdGUiLCJhZ2VudDpjcmVhdGUiXX0." +
-	"bKPINZyhzX2Ls1QM--UV56cC-vm5uymT8y-DmEhY1dE"
-
-// Token for the agent with name "agent-007" with scopes ["test:read"]
-const agentToken007 = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
-	"eyJpZCI6MTAwMDEsIm5hbWUiOiJhZ2VudC0wMDciLCJzY29wZXMiOlsidGVzdDpyZWFkIl0sInR5cGUiOiJhZ2VudCJ9." +
-	"x2qjMYZT55-V6fH0z0hVVdM8jQAsiMzyxKQK2iEUiQA"
-
-// Token for the agent with name "agent-007" with scopes ["test:read","agent:create"]
-const agentToken007Updated = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
-	"eyJpZCI6MzEsIm5hbWUiOiJhZ2VudC0wMDEiLCJzY29wZXMiOlsidGVzdDpyZWFkIiwiYWdlbnQ6Y3JlYXRlIl0sInR5cGUiOiJhZ2VudCJ9." +
-	"0u_SkfkJjuq8jyax8jwLdAzHUl7J0g0a6jkN9gLoJl4"
-
-// Token for the user with github name "foi-boi" and github login "foi"
-// It has a extra scope "config:refresh" along with default scope
-const validTokenWithConfigRefreshScope = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
-	"eyJpZCI6MTMsImxvZ2luIjoiZm9pIiwibmFtZSI6ImZvaS1ib2kiLCJzY29wZXMiOlsicmF0aW5nOnJlYWQiLCJyYXRpbmc6d3JpdGUiLCJjb25maWc6cmVmcmVzaCJdfQ." +
-	"7eA0J6xbOOkth2dsPd9z_VxmZVHjIwXamQWyCq-Jur8"
 
 func UpdateAgentChecker(tc *testutils.TestConfig) *goahttpcheck.APIChecker {
 	service := auth.NewService(tc.APIConfig, tc.JWTSigningKey())
@@ -64,14 +41,19 @@ func UpdateAgentChecker(tc *testutils.TestConfig) *goahttpcheck.APIChecker {
 	return checker
 }
 
-func TestUpdateAgent_Http(t *testing.T) {
+func TestUpdateAgent_Http_NewAgent(t *testing.T) {
 	tc := testutils.Setup(t)
 	testutils.LoadFixtures(t, tc.FixturePath())
 
-	data := []byte(`{"name": "agent-007","scopes": ["test:read"]}`)
+	// user with agent:create scope
+	user, token, err := tc.UserWithScopes("foo", "agent:create")
+	assert.Equal(t, user.GithubLogin, "foo")
+	assert.NoError(t, err)
+
+	data := []byte(`{"name": "agent-007","scopes": ["catalog:refresh"]}`)
 
 	UpdateAgentChecker(tc).Test(t, http.MethodPut, "/system/user/agent").
-		WithHeader("Authorization", validTokenWithAgentCreateScope).WithBody(data).
+		WithHeader("Authorization", token).WithBody(data).
 		Check().
 		HasStatus(200).Cb(func(r *http.Response) {
 		b, readErr := ioutil.ReadAll(r.Body)
@@ -82,7 +64,12 @@ func TestUpdateAgent_Http(t *testing.T) {
 		marshallErr := json.Unmarshal([]byte(b), &res)
 		assert.NoError(t, marshallErr)
 
-		assert.Equal(t, agentToken007, res.Token)
+		// expected jwt for agent-007
+		agent, agentToken, err := tc.AgentWithScopes("agent-007", "catalog:refresh")
+		assert.Equal(t, agent.AgentName, "agent-007")
+		assert.NoError(t, err)
+
+		assert.Equal(t, agentToken, res.Token)
 	})
 }
 
@@ -90,10 +77,15 @@ func TestUpdateAgent_Http_NormalUserExistWithName(t *testing.T) {
 	tc := testutils.Setup(t)
 	testutils.LoadFixtures(t, tc.FixturePath())
 
-	data := []byte(`{"name": "foo-bar","scopes": ["test:read"]}`)
+	// user with agent:create scope
+	user, token, err := tc.UserWithScopes("foo", "agent:create")
+	assert.Equal(t, user.GithubLogin, "foo")
+	assert.NoError(t, err)
+
+	data := []byte(`{"name": "foo","scopes": ["catalog:refresh"]}`)
 
 	UpdateAgentChecker(tc).Test(t, http.MethodPut, "/system/user/agent").
-		WithHeader("Authorization", validTokenWithAgentCreateScope).WithBody(data).
+		WithHeader("Authorization", token).WithBody(data).
 		Check().
 		HasStatus(400).Cb(func(r *http.Response) {
 		b, readErr := ioutil.ReadAll(r.Body)
@@ -104,7 +96,7 @@ func TestUpdateAgent_Http_NormalUserExistWithName(t *testing.T) {
 		marshallErr := json.Unmarshal([]byte(b), &err)
 		assert.NoError(t, marshallErr)
 
-		assert.EqualError(t, err, "user exists with name: foo-bar")
+		assert.EqualError(t, err, "user exists with name: foo")
 	})
 }
 
@@ -112,10 +104,15 @@ func TestUpdateAgent_Http_InvalidScopeCase(t *testing.T) {
 	tc := testutils.Setup(t)
 	testutils.LoadFixtures(t, tc.FixturePath())
 
+	// user with agent:create scope
+	user, token, err := tc.UserWithScopes("foo", "agent:create")
+	assert.Equal(t, user.GithubLogin, "foo")
+	assert.NoError(t, err)
+
 	data := []byte(`{"name": "agent-001","scopes": ["invalid:scope"]}`)
 
 	UpdateAgentChecker(tc).Test(t, http.MethodPut, "/system/user/agent").
-		WithHeader("Authorization", validTokenWithAgentCreateScope).WithBody(data).
+		WithHeader("Authorization", token).WithBody(data).
 		Check().
 		HasStatus(400).Cb(func(r *http.Response) {
 		b, readErr := ioutil.ReadAll(r.Body)
@@ -134,10 +131,15 @@ func TestUpdateAgent_Http_UpdateCase(t *testing.T) {
 	tc := testutils.Setup(t)
 	testutils.LoadFixtures(t, tc.FixturePath())
 
-	data := []byte(`{"name": "agent-001","scopes": ["test:read","agent:create"]}`)
+	// user with agent:create scope
+	user, token, err := tc.UserWithScopes("foo", "agent:create")
+	assert.Equal(t, user.GithubLogin, "foo")
+	assert.NoError(t, err)
+
+	data := []byte(`{"name": "agent-001","scopes": ["catalog:refresh","agent:create"]}`)
 
 	UpdateAgentChecker(tc).Test(t, http.MethodPut, "/system/user/agent").
-		WithHeader("Authorization", validTokenWithAgentCreateScope).WithBody(data).
+		WithHeader("Authorization", token).WithBody(data).
 		Check().
 		HasStatus(200).Cb(func(r *http.Response) {
 		b, readErr := ioutil.ReadAll(r.Body)
@@ -148,7 +150,12 @@ func TestUpdateAgent_Http_UpdateCase(t *testing.T) {
 		marshallErr := json.Unmarshal([]byte(b), &res)
 		assert.NoError(t, marshallErr)
 
-		assert.Equal(t, agentToken007Updated, res.Token)
+		// expected jwt for agent-001 after updating scopes
+		agent, agentToken, err := tc.AgentWithScopes("agent-001", "catalog:refresh", "agent:create")
+		assert.Equal(t, agent.AgentName, "agent-001")
+		assert.NoError(t, err)
+
+		assert.Equal(t, agentToken, res.Token)
 	})
 }
 
@@ -164,16 +171,21 @@ func TestRefreshConfig_Http(t *testing.T) {
 	tc := testutils.Setup(t)
 	testutils.LoadFixtures(t, tc.FixturePath())
 
+	// user with config:refresh scope
+	user, token, err := tc.UserWithScopes("foo", "config:refresh")
+	assert.Equal(t, user.GithubLogin, "foo")
+	assert.NoError(t, err)
+
 	// DB is populated using text fixture, so it has by default value `testChecksum` in table
 	config := &model.Config{}
-	err := tc.DB().First(config).Error
+	err = tc.DB().First(config).Error
 	assert.NoError(t, err)
 	assert.Equal(t, "testChecksum", config.Checksum)
 
 	data := []byte(`{"force": false}`)
 
 	RefreshConfigChecker(tc).Test(t, http.MethodPost, "/system/config/refresh").
-		WithHeader("Authorization", validTokenWithConfigRefreshScope).
+		WithHeader("Authorization", token).
 		WithBody(data).Check().
 		HasStatus(200).Cb(func(r *http.Response) {
 		b, readErr := ioutil.ReadAll(r.Body)
@@ -196,16 +208,21 @@ func TestRefreshConfig_Http_ForceRefresh(t *testing.T) {
 	tc := testutils.Setup(t)
 	testutils.LoadFixtures(t, tc.FixturePath())
 
+	// user with config:refresh scope
+	user, token, err := tc.UserWithScopes("foo", "config:refresh")
+	assert.Equal(t, user.GithubLogin, "foo")
+	assert.NoError(t, err)
+
 	// DB is populated using text fixture, so it has by default value `testChecksum` in table
 	config := &model.Config{}
-	err := tc.DB().First(config).Error
+	err = tc.DB().First(config).Error
 	assert.NoError(t, err)
 	assert.Equal(t, "testChecksum", config.Checksum)
 
 	data := []byte(`{"force": true}`)
 
 	RefreshConfigChecker(tc).Test(t, http.MethodPost, "/system/config/refresh").
-		WithHeader("Authorization", validTokenWithConfigRefreshScope).
+		WithHeader("Authorization", token).
 		WithBody(data).Check().
 		HasStatus(200).Cb(func(r *http.Response) {
 		b, readErr := ioutil.ReadAll(r.Body)

--- a/api/pkg/service/catalog/catalog_test.go
+++ b/api/pkg/service/catalog/catalog_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
 	"github.com/tektoncd/hub/api/gen/catalog"
 	"github.com/tektoncd/hub/api/pkg/app"
 	"github.com/tektoncd/hub/api/pkg/service/auth"
@@ -42,8 +41,13 @@ func TestRefresh(t *testing.T) {
 	tc := testutils.Setup(t)
 	testutils.LoadFixtures(t, tc.FixturePath())
 
+	// user with catalog:refresh scope
+	user, _, err := tc.UserWithScopes("foo", "catalog:refresh")
+	assert.Equal(t, user.GithubLogin, "foo")
+	assert.NoError(t, err)
+
 	catalogSvc := NewServiceTest(tc)
-	ctx := auth.WithUserID(context.Background(), 11)
+	ctx := auth.WithUserID(context.Background(), user.ID)
 
 	payload := &catalog.RefreshPayload{}
 	job, err := catalogSvc.Refresh(ctx, payload)
@@ -56,8 +60,13 @@ func TestRefreshAgain(t *testing.T) {
 	tc := testutils.Setup(t)
 	testutils.LoadFixtures(t, tc.FixturePath())
 
+	// user with catalog:refresh scopes
+	user, _, err := tc.UserWithScopes("foo", "catalog:refresh")
+	assert.Equal(t, user.GithubLogin, "foo")
+	assert.NoError(t, err)
+
 	catalogSvc := NewServiceTest(tc)
-	ctx := auth.WithUserID(context.Background(), 11)
+	ctx := auth.WithUserID(context.Background(), user.ID)
 
 	payload := &catalog.RefreshPayload{}
 	res, err := catalogSvc.Refresh(ctx, payload)

--- a/api/pkg/service/rating/rating_test.go
+++ b/api/pkg/service/rating/rating_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
 	"github.com/tektoncd/hub/api/gen/rating"
 	"github.com/tektoncd/hub/api/pkg/service/auth"
 	"github.com/tektoncd/hub/api/pkg/testutils"
@@ -29,10 +28,14 @@ func TestGet(t *testing.T) {
 	tc := testutils.Setup(t)
 	testutils.LoadFixtures(t, tc.FixturePath())
 
-	ratingSvc := New(tc)
+	// user with rating:read scope
+	user, _, err := tc.UserWithScopes("foo", "rating:read")
+	assert.Equal(t, user.GithubLogin, "foo")
+	assert.NoError(t, err)
 
-	ctx := auth.WithUserID(context.Background(), 11)
-	payload := &rating.GetPayload{ID: 1, Token: "token"}
+	ratingSvc := New(tc)
+	ctx := auth.WithUserID(context.Background(), user.ID)
+	payload := &rating.GetPayload{ID: 1}
 	rat, err := ratingSvc.Get(ctx, payload)
 	assert.NoError(t, err)
 	assert.Equal(t, 5, rat.Rating)
@@ -42,9 +45,14 @@ func TestGet_RatingNotFound(t *testing.T) {
 	tc := testutils.Setup(t)
 	testutils.LoadFixtures(t, tc.FixturePath())
 
+	// user with rating:read scope
+	user, _, err := tc.UserWithScopes("foo", "rating:read")
+	assert.Equal(t, user.GithubLogin, "foo")
+	assert.NoError(t, err)
+
 	ratingSvc := New(tc)
-	ctx := auth.WithUserID(context.Background(), 11)
-	payload := &rating.GetPayload{ID: 3, Token: "token"}
+	ctx := auth.WithUserID(context.Background(), user.ID)
+	payload := &rating.GetPayload{ID: 3}
 	rat, err := ratingSvc.Get(ctx, payload)
 	assert.NoError(t, err)
 	assert.Equal(t, -1, rat.Rating)
@@ -54,10 +62,15 @@ func TestGet_ResourceNotFound(t *testing.T) {
 	tc := testutils.Setup(t)
 	testutils.LoadFixtures(t, tc.FixturePath())
 
+	// user with rating:read scope
+	user, _, err := tc.UserWithScopes("foo", "rating:read")
+	assert.Equal(t, user.GithubLogin, "foo")
+	assert.NoError(t, err)
+
 	ratingSvc := New(tc)
-	ctx := auth.WithUserID(context.Background(), 11)
-	payload := &rating.GetPayload{ID: 99, Token: "token"}
-	_, err := ratingSvc.Get(ctx, payload)
+	ctx := auth.WithUserID(context.Background(), user.ID)
+	payload := &rating.GetPayload{ID: 99}
+	_, err = ratingSvc.Get(ctx, payload)
 	assert.Error(t, err)
 	assert.EqualError(t, err, "resource not found")
 }
@@ -66,10 +79,15 @@ func TestUpdate(t *testing.T) {
 	tc := testutils.Setup(t)
 	testutils.LoadFixtures(t, tc.FixturePath())
 
+	// user with rating:write scope
+	user, _, err := tc.UserWithScopes("foo", "rating:write")
+	assert.Equal(t, user.GithubLogin, "foo")
+	assert.NoError(t, err)
+
 	ratingSvc := New(tc)
-	ctx := auth.WithUserID(context.Background(), 11)
-	payload := &rating.UpdatePayload{ID: 1, Rating: 3, Token: "token"}
-	err := ratingSvc.Update(ctx, payload)
+	ctx := auth.WithUserID(context.Background(), user.ID)
+	payload := &rating.UpdatePayload{ID: 1, Rating: 3}
+	err = ratingSvc.Update(ctx, payload)
 	assert.NoError(t, err)
 }
 
@@ -77,10 +95,15 @@ func TestUpdate_ResourceNotFound(t *testing.T) {
 	tc := testutils.Setup(t)
 	testutils.LoadFixtures(t, tc.FixturePath())
 
+	// user with rating:write scope
+	user, _, err := tc.UserWithScopes("foo", "rating:write")
+	assert.Equal(t, user.GithubLogin, "foo")
+	assert.NoError(t, err)
+
 	ratingSvc := New(tc)
-	ctx := auth.WithUserID(context.Background(), 11)
-	payload := &rating.UpdatePayload{ID: 99, Rating: 3, Token: "token"}
-	err := ratingSvc.Update(ctx, payload)
+	ctx := auth.WithUserID(context.Background(), user.ID)
+	payload := &rating.UpdatePayload{ID: 99, Rating: 3}
+	err = ratingSvc.Update(ctx, payload)
 	assert.Error(t, err)
 	assert.EqualError(t, err, "resource not found")
 }

--- a/api/pkg/testutils/utils.go
+++ b/api/pkg/testutils/utils.go
@@ -17,6 +17,10 @@ package testutils
 import (
 	"bytes"
 	"encoding/json"
+
+	"github.com/dgrijalva/jwt-go"
+	"github.com/tektoncd/hub/api/pkg/db/model"
+	"github.com/tektoncd/hub/api/pkg/token"
 )
 
 // FormatJSON formats json string to be added to golden file
@@ -27,4 +31,84 @@ func FormatJSON(b []byte) (string, error) {
 		return "", err
 	}
 	return string(formatted.Bytes()), nil
+}
+
+// UserWithScopes returns JWT for user with required scopes
+// User will have same github login and github name in db
+func (tc *TestConfig) UserWithScopes(name string, scopes ...string) (*model.User, string, error) {
+
+	user := &model.User{GithubLogin: name, GithubName: name, Type: model.NormalUserType}
+	if err := tc.DB().Where(&model.User{GithubLogin: name}).
+		FirstOrCreate(user).Error; err != nil {
+		return nil, "", err
+	}
+
+	if err := tc.AddScopesForUser(user.ID, scopes); err != nil {
+		return nil, "", err
+	}
+
+	claim := jwt.MapClaims{
+		"id":     user.ID,
+		"login":  user.GithubLogin,
+		"name":   user.GithubName,
+		"scopes": scopes,
+	}
+
+	token, err := token.Create(claim, tc.JWTSigningKey())
+	if err != nil {
+		return nil, "", err
+	}
+
+	return user, token, nil
+}
+
+// AgentWithScopes returns JWT for user with required scopes
+func (tc *TestConfig) AgentWithScopes(name string, scopes ...string) (*model.User, string, error) {
+
+	user := &model.User{AgentName: name, Type: model.AgentUserType}
+	if err := tc.DB().Where(&model.User{AgentName: name}).
+		FirstOrCreate(user).Error; err != nil {
+		return nil, "", err
+	}
+
+	if err := tc.AddScopesForUser(user.ID, scopes); err != nil {
+		return nil, "", err
+	}
+
+	claim := jwt.MapClaims{
+		"id":     user.ID,
+		"name":   user.AgentName,
+		"type":   user.Type,
+		"scopes": scopes,
+	}
+
+	token, err := token.Create(claim, tc.JWTSigningKey())
+	if err != nil {
+		return nil, "", err
+	}
+
+	return user, token, nil
+}
+
+// AddScopesForUser adds scopes for passed User ID
+func (tc *TestConfig) AddScopesForUser(userID uint, scopes []string) error {
+
+	for _, s := range scopes {
+
+		// rating scopes are not saved in db, they are in Data object read from config
+		if s == "rating:read" || s == "rating:write" {
+			continue
+		}
+
+		scope := &model.Scope{}
+		if err := tc.DB().Where(&model.Scope{Name: s}).First(&scope).Error; err != nil {
+			return err
+		}
+
+		us := &model.UserScope{UserID: userID, ScopeID: scope.ID}
+		if err := tc.DB().FirstOrCreate(us).Error; err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/api/test/fixtures/scopes.yaml
+++ b/api/test/fixtures/scopes.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 - id: 1
-  name: test:read
+  name: catalog:refresh
   created_at: 2016-01-01 12:30:12 UTC
   updated_at: 2016-01-01 12:30:12 UTC
   

--- a/api/test/fixtures/user_resource_ratings.yaml
+++ b/api/test/fixtures/user_resource_ratings.yaml
@@ -18,10 +18,3 @@
   rating: 5
   created_at: 2016-01-01 12:30:12 UTC
   updated_at: 2016-01-01 12:30:12 UTC
-
-- id: 2
-  user_id: 21
-  resource_id: 1
-  rating: 5
-  created_at: 2016-01-01 12:30:12 UTC
-  updated_at: 2016-01-01 12:30:12 UTC

--- a/api/test/fixtures/user_scopes.yaml
+++ b/api/test/fixtures/user_scopes.yaml
@@ -14,9 +14,3 @@
 
 - user_id: 11
   scope_id: 2
-
-- user_id: 13
-  scope_id: 3
-
-- user_id: 31
-  scope_id: 1

--- a/api/test/fixtures/users.yaml
+++ b/api/test/fixtures/users.yaml
@@ -13,27 +13,13 @@
 # limitations under the License.
 
 - id: 11
-  github_name: foo-bar
+  github_name: foo
   github_login: foo
   type: user
   created_at: 2016-01-01 12:30:12 UTC
   updated_at: 2016-01-01 12:30:12 UTC
 
-- id: 13
-  github_name: foi-boi
-  github_login: foi
-  type: user
-  created_at: 2016-01-01 12:30:12 UTC
-  updated_at: 2016-01-01 12:30:12 UTC
-
 - id: 21
-  github_name: abc-def
-  github_login: abc
-  type: user
-  created_at: 2016-01-01 12:30:12 UTC
-  updated_at: 2016-01-01 12:30:12 UTC
-
-- id: 31
   agent_name: agent-001
   type: agent
   created_at: 2016-01-01 12:30:12 UTC


### PR DESCRIPTION
This adds function to create jwt with required scopes on TestConfig
for tests instead of hardcoding jwt.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

