### PR TITLE
CLI: Adds get command

### DIFF
--- a/api/pkg/cli/cmd/get/get.go
+++ b/api/pkg/cli/cmd/get/get.go
@@ -1,0 +1,106 @@
+// Copyright © 2020 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package get
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/tektoncd/hub/api/pkg/cli/app"
+	"github.com/tektoncd/hub/api/pkg/cli/flag"
+	"github.com/tektoncd/hub/api/pkg/cli/hub"
+	"github.com/tektoncd/hub/api/pkg/cli/printer"
+)
+
+type options struct {
+	cli     app.CLI
+	catalog string
+	version string
+	kind    string
+	args    []string
+}
+
+func Command(cli app.CLI) *cobra.Command {
+
+	opts := &options{cli: cli}
+
+	cmd := &cobra.Command{
+		Use:   "get",
+		Short: "Get resource manifest by its name, kind, catalog, and version",
+		Long:  ``,
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
+		SilenceUsage: true,
+	}
+
+	cmd.AddCommand(
+		commandForKind("task", opts),
+		commandForKind("pipeline", opts),
+	)
+
+	cmd.PersistentFlags().StringVar(&opts.catalog, "catalog", "tekton", "Name of Catalog to which resource belongs to.")
+	cmd.PersistentFlags().StringVar(&opts.version, "version", "", "Version of Resource")
+
+	return cmd
+}
+
+// commandForKind creates a cobra.Command that when run sets
+// opts.Kind and opts.Args and invokes opts.run
+func commandForKind(kind string, opts *options) *cobra.Command {
+
+	return &cobra.Command{
+		Use:          kind,
+		Short:        "Get " + kind + " by name, catalog and version",
+		Long:         ``,
+		SilenceUsage: true,
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.kind = kind
+			opts.args = args
+			return opts.run()
+		},
+	}
+}
+
+func (opts *options) run() error {
+
+	if err := opts.validate(); err != nil {
+		return err
+	}
+
+	hubClient := opts.cli.Hub()
+
+	resource := hubClient.GetResource(hub.ResourceOption{
+		Name:    opts.name(),
+		Catalog: opts.catalog,
+		Kind:    opts.kind,
+		Version: opts.version,
+	})
+
+	out := opts.cli.Stream().Out
+	return printer.New(out).Raw(resource.Manifest())
+}
+
+func (opts *options) validate() error {
+	return flag.ValidateVersion(opts.version)
+}
+
+func (opts *options) name() string {
+	return strings.TrimSpace(opts.args[0])
+}

--- a/api/pkg/cli/cmd/get/get_test.go
+++ b/api/pkg/cli/cmd/get/get_test.go
@@ -1,0 +1,214 @@
+// Copyright © 2020 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package get
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	res "github.com/tektoncd/hub/api/gen/resource"
+	"github.com/tektoncd/hub/api/pkg/cli/test"
+	goa "goa.design/goa/v3/pkg"
+	"gopkg.in/h2non/gock.v1"
+	"gotest.tools/v3/golden"
+)
+
+const api string = "http://test.hub.cli"
+
+var resource = &res.Resource{
+	ID:   1,
+	Name: "foo",
+	Kind: "Task",
+	Catalog: &res.Catalog{
+		ID:   1,
+		Name: "tekton",
+		Type: "community",
+	},
+	Rating: 4.8,
+	LatestVersion: &res.Version{
+		ID:                  11,
+		Version:             "0.1",
+		Description:         "Description for task abc version 0.1",
+		DisplayName:         "foo-0.1",
+		MinPipelinesVersion: "0.11",
+		RawURL:              "http://raw.github.url/foo/0.1/foo.yaml",
+		WebURL:              "http://web.github.com/foo/0.1/foo.yaml",
+		UpdatedAt:           "2020-01-01 12:00:00 +0000 UTC",
+	},
+	Tags: []*res.Tag{
+		&res.Tag{
+			ID:   3,
+			Name: "tag3",
+		},
+		&res.Tag{
+			ID:   1,
+			Name: "tag1",
+		},
+	},
+	Versions: []*res.Version{
+		&res.Version{
+			ID:      11,
+			Version: "0.1",
+		},
+	},
+}
+
+var resVersion = &res.Version{
+	ID:                  11,
+	Version:             "0.3",
+	DisplayName:         "foo",
+	Description:         "Description for task abc version 0.3",
+	MinPipelinesVersion: "0.12",
+	RawURL:              "http://raw.github.url/foo/0.3/foo.yaml",
+	WebURL:              "http://web.github.com/foo/0.3/foo.yaml",
+	UpdatedAt:           "2020-01-01 12:00:00 +0000 UTC",
+	Resource: &res.Resource{
+		ID:   1,
+		Name: "foo",
+		Kind: "Task",
+		Catalog: &res.Catalog{
+			ID:   1,
+			Name: "tekton",
+			Type: "community",
+		},
+		Rating: 4.8,
+		Tags: []*res.Tag{
+			&res.Tag{
+				ID:   3,
+				Name: "tag3",
+			},
+			&res.Tag{
+				ID:   1,
+				Name: "tag1",
+			},
+		},
+	},
+}
+
+func TestValidate(t *testing.T) {
+	opt := options{
+		version: "0.1",
+	}
+	err := opt.validate()
+	assert.NoError(t, err)
+
+	opt = options{
+		version: "0.3.1",
+	}
+	err = opt.validate()
+	assert.NoError(t, err)
+}
+
+func TestValidate_ErrorCase(t *testing.T) {
+	opt := options{
+		version: "abc",
+	}
+	err := opt.validate()
+	assert.EqualError(t, err, "invalid value \"abc\" set for option version. valid eg. 0.1, 1.2.1")
+}
+
+func TestGet_WithoutVersion(t *testing.T) {
+	cli := test.NewCLI()
+
+	defer gock.Off()
+
+	res := res.NewViewedResource(resource, "default")
+	gock.New(test.API).
+		Get("/resource").
+		Reply(200).
+		JSON(&res.Projected)
+
+	gock.New("http://raw.github.url").
+		Get("/foo").
+		Reply(200).
+		File("./testdata/foo-v0.1.yaml")
+
+	buf := new(bytes.Buffer)
+	cli.SetStream(buf, buf)
+
+	opt := &options{
+		cli:     cli,
+		args:    []string{"foo"},
+		catalog: "tekton",
+	}
+
+	err := opt.run()
+	assert.NoError(t, err)
+	golden.Assert(t, buf.String(), fmt.Sprintf("%s.golden", t.Name()))
+	assert.Equal(t, gock.IsDone(), true)
+}
+
+func TestGet_WithVersion(t *testing.T) {
+	cli := test.NewCLI()
+
+	defer gock.Off()
+
+	res := res.NewViewedVersion(resVersion, "default")
+	gock.New(test.API).
+		Get("/resource").
+		Reply(200).
+		JSON(&res.Projected)
+
+	gock.New("http://raw.github.url").
+		Get("/foo").
+		Reply(200).
+		File("./testdata/foo-v0.3.yaml")
+
+	buf := new(bytes.Buffer)
+	cli.SetStream(buf, buf)
+
+	opt := &options{
+		cli:     cli,
+		args:    []string{"foo"},
+		catalog: "tekton",
+		version: "0.3",
+	}
+
+	err := opt.run()
+	assert.NoError(t, err)
+	golden.Assert(t, buf.String(), fmt.Sprintf("%s.golden", t.Name()))
+	assert.Equal(t, gock.IsDone(), true)
+}
+
+func TestGet_ResourceNotFound(t *testing.T) {
+	cli := test.NewCLI()
+
+	defer gock.Off()
+
+	gock.New(test.API).
+		Get("/resource").
+		Reply(404).
+		JSON(&goa.ServiceError{
+			ID:      "123456",
+			Name:    "not-found",
+			Message: "resource not found",
+		})
+
+	buf := new(bytes.Buffer)
+	cli.SetStream(buf, buf)
+
+	opt := &options{
+		cli:     cli,
+		args:    []string{"xyz"},
+		catalog: "tekton",
+	}
+
+	err := opt.run()
+	assert.Error(t, err)
+	assert.EqualError(t, err, "No Resource Found")
+	assert.Equal(t, gock.IsDone(), true)
+}

--- a/api/pkg/cli/cmd/get/testdata/TestGet_WithVersion.golden
+++ b/api/pkg/cli/cmd/get/testdata/TestGet_WithVersion.golden
@@ -1,0 +1,13 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: foo
+  annotations:
+    tekton.dev/pipelines.minVersion: '0.13.1'
+    tekton.dev/tags: cli
+    tekton.dev/displayName: 'foo-bar'
+spec:
+  description: >-
+    v0.3 Task to run foo
+

--- a/api/pkg/cli/cmd/get/testdata/TestGet_WithoutVersion.golden
+++ b/api/pkg/cli/cmd/get/testdata/TestGet_WithoutVersion.golden
@@ -1,0 +1,13 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: foo
+  annotations:
+    tekton.dev/pipelines.minVersion: '0.12.1'
+    tekton.dev/tags: cli
+    tekton.dev/displayName: 'foo-bar'
+spec:
+  description: >-
+    v0.1 Task to run foo
+

--- a/api/pkg/cli/cmd/get/testdata/foo-v0.1.yaml
+++ b/api/pkg/cli/cmd/get/testdata/foo-v0.1.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: foo
+  annotations:
+    tekton.dev/pipelines.minVersion: '0.12.1'
+    tekton.dev/tags: cli
+    tekton.dev/displayName: 'foo-bar'
+spec:
+  description: >-
+    v0.1 Task to run foo

--- a/api/pkg/cli/cmd/get/testdata/foo-v0.3.yaml
+++ b/api/pkg/cli/cmd/get/testdata/foo-v0.3.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: foo
+  annotations:
+    tekton.dev/pipelines.minVersion: '0.13.1'
+    tekton.dev/tags: cli
+    tekton.dev/displayName: 'foo-bar'
+spec:
+  description: >-
+    v0.3 Task to run foo

--- a/api/pkg/cli/cmd/root.go
+++ b/api/pkg/cli/cmd/root.go
@@ -16,8 +16,8 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
-
 	"github.com/tektoncd/hub/api/pkg/cli/app"
+	"github.com/tektoncd/hub/api/pkg/cli/cmd/get"
 	"github.com/tektoncd/hub/api/pkg/cli/cmd/search"
 	"github.com/tektoncd/hub/api/pkg/cli/hub"
 )
@@ -44,9 +44,10 @@ func Root(cli app.CLI) *cobra.Command {
 
 	cmd.AddCommand(
 		search.Command(cli),
+		get.Command(cli),
 	)
 
-	cmd.PersistentFlags().StringVar(&apiURL, "api-server", hub.URL, "Hub API Server URL")
+	cmd.PersistentFlags().StringVar(&apiURL, "api-server", hub.URL(), "Hub API Server URL")
 
 	return cmd
 }

--- a/api/pkg/cli/flag/validate.go
+++ b/api/pkg/cli/flag/validate.go
@@ -16,6 +16,7 @@ package flag
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 )
 
@@ -47,4 +48,16 @@ func AllEmpty(arr ...[]string) bool {
 		}
 	}
 	return true
+}
+
+// ValidateVersion validates version format
+func ValidateVersion(version string) error {
+	if version == "" {
+		return nil
+	}
+	var re = regexp.MustCompile(`^(\d+\.)?(\d+\.)?(\*|\d+)$`)
+	if !re.MatchString(version) {
+		return fmt.Errorf("invalid value %q set for option version. valid eg. 0.1, 1.2.1", version)
+	}
+	return nil
 }

--- a/api/pkg/cli/flag/validate_test.go
+++ b/api/pkg/cli/flag/validate_test.go
@@ -38,3 +38,17 @@ func TestTrimArray(t *testing.T) {
 	want := []string{"a", "b", "abc", "xyz", "mno"}
 	assert.Equal(t, want, res)
 }
+
+func TestValidateVersion(t *testing.T) {
+
+	// Valid Case
+	err := ValidateVersion("0.1")
+	assert.NoError(t, err)
+
+	err = ValidateVersion("0.1.1")
+	assert.NoError(t, err)
+
+	// Invalid Case
+	err = ValidateVersion("abc")
+	assert.EqualError(t, err, "invalid value \"abc\" set for option version. valid eg. 0.1, 1.2.1")
+}

--- a/api/pkg/cli/hub/get_resource.go
+++ b/api/pkg/cli/hub/get_resource.go
@@ -1,0 +1,107 @@
+// Copyright © 2020 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	rclient "github.com/tektoncd/hub/api/gen/http/resource/client"
+)
+
+// ResourceOption defines option associated with API to fetch a
+// particular resource
+type ResourceOption struct {
+	Name    string
+	Catalog string
+	Version string
+	Kind    string
+}
+
+// ResourceResult defines API response
+type ResourceResult struct {
+	data    []byte
+	status  int
+	err     error
+	version string
+}
+
+// GetResource queries the data using Hub Endpoint
+func (h *client) GetResource(opt ResourceOption) ResourceResult {
+	data, status, err := h.Get(opt.Endpoint())
+
+	return ResourceResult{
+		data:    data,
+		version: opt.Version,
+		status:  status,
+		err:     err,
+	}
+}
+
+// Endpoint computes the endpoint url using input provided
+func (opt ResourceOption) Endpoint() string {
+	if opt.Version != "" {
+		// API: /resource/<catalog>/<kind>/<name>/<version>
+		return fmt.Sprintf("/resource/%s/%s/%s/%s", opt.Catalog, opt.Kind, opt.Name, opt.Version)
+	}
+	// API: /resource/<catalog>/<kind>/<name>
+	return fmt.Sprintf("/resource/%s/%s/%s", opt.Catalog, opt.Kind, opt.Name)
+}
+
+// RawURL returns the raw url of the resource yaml file
+func (gr *ResourceResult) RawURL() (string, error) {
+	if gr.err != nil {
+		return "", gr.err
+	}
+
+	if gr.status == http.StatusNotFound {
+		return "", fmt.Errorf("No Resource Found")
+	}
+
+	if gr.version != "" {
+		resVersion := rclient.VersionResponse{}
+		if err := json.Unmarshal(gr.data, &resVersion); err != nil {
+			return "", err
+		}
+		return *resVersion.RawURL, nil
+	}
+
+	res := rclient.ResourceResponse{}
+	if err := json.Unmarshal(gr.data, &res); err != nil {
+		return "", err
+	}
+	return *res.LatestVersion.RawURL, nil
+}
+
+// Manifest gets the resource from catalog
+func (gr *ResourceResult) Manifest() ([]byte, error) {
+	rawURL, err := gr.RawURL()
+	if err != nil {
+		return nil, err
+	}
+
+	data, status, err := httpGet(rawURL)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if status != http.StatusOK {
+		return nil, fmt.Errorf("failed to fetch resource from catalog")
+	}
+
+	return data, nil
+}

--- a/api/pkg/cli/hub/get_resource_test.go
+++ b/api/pkg/cli/hub/get_resource_test.go
@@ -12,43 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package test
+package hub
 
 import (
-	"io"
+	"testing"
 
-	"github.com/tektoncd/hub/api/pkg/cli/app"
-	"github.com/tektoncd/hub/api/pkg/cli/hub"
+	"github.com/stretchr/testify/assert"
 )
 
-// API is test URL
-const API string = "http://test.hub.cli"
+func TestGetResourceEndpoint(t *testing.T) {
 
-type cli struct {
-	hub    hub.Client
-	stream app.Stream
-}
-
-var _ app.CLI = (*cli)(nil)
-
-func NewCLI() *cli {
-	h := hub.NewClient()
-	h.SetURL(API)
-
-	return &cli{
-		stream: app.Stream{},
-		hub:    h,
+	opt := ResourceOption{
+		Version: "",
+		Catalog: "tekton",
+		Name:    "abc",
+		Kind:    "task",
 	}
-}
+	url := opt.Endpoint()
+	assert.Equal(t, "/resource/tekton/task/abc", url)
 
-func (c *cli) Stream() app.Stream {
-	return c.stream
-}
-
-func (c *cli) SetStream(out, err io.Writer) {
-	c.stream = app.Stream{Out: out, Err: err}
-}
-
-func (c *cli) Hub() hub.Client {
-	return c.hub
+	opt.Version = "0.1.1"
+	url = opt.Endpoint()
+	assert.Equal(t, "/resource/tekton/task/abc/0.1.1", url)
 }

--- a/api/pkg/cli/hub/search.go
+++ b/api/pkg/cli/hub/search.go
@@ -43,6 +43,15 @@ type SearchResult struct {
 	err       error
 }
 
+// Search queries the data using Hub Endpoint
+func (h *client) Search(so SearchOption) SearchResult {
+	data, status, err := h.Get(so.Endpoint())
+	if status == http.StatusNotFound {
+		err = nil
+	}
+	return SearchResult{data: data, status: status, err: err}
+}
+
 // Raw returns API response as byte array
 func (sr *SearchResult) Raw() ([]byte, error) {
 	return sr.data, sr.err

--- a/api/pkg/cli/printer/print.go
+++ b/api/pkg/cli/printer/print.go
@@ -54,3 +54,13 @@ func (p *Printer) Tabbed(tmpl *template.Template, templateData interface{}) erro
 
 	return tmpl.Execute(w, templateData)
 }
+
+// Raw prints the raw byte array to printer's output stream
+func (p *Printer) Raw(data []byte, err error) error {
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintln(p.out, string(data))
+	return nil
+}


### PR DESCRIPTION
This adds get command, which will fetch the resource file from the catalog.
usage: tkn-hub get task/pipeline <name> --version --catalog
There are 2 subcommands: task and pipeline which are supported by hub currently
flags:
--version: a version of the resource, fetches the latest version by default
--catalog: catalog name to fetch the resource from. Default is tekton which is
the community catalog (tektoncd/catalog).

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

