### PR TITLE
CLI: Updates examples to have Tekton Resource in Title case

### DIFF
--- a/api/pkg/cli/cmd/get/get.go
+++ b/api/pkg/cli/cmd/get/get.go
@@ -33,13 +33,13 @@ type options struct {
 }
 
 var cmdExamples string = `
-Get a %s of name 'foo':
+Get a %S of name 'foo':
 
     tkn hub get %s foo
 
 or
 
-Get a %s of name 'foo' of version '0.3':
+Get a %S of name 'foo' of version '0.3':
 
     tkn hub get %s foo --version 0.3
 `
@@ -75,7 +75,7 @@ func commandForKind(kind string, opts *options) *cobra.Command {
 
 	return &cobra.Command{
 		Use:          kind,
-		Short:        "Get " + kind + " by name, catalog and version",
+		Short:        "Get " + strings.Title(kind) + " by name, catalog and version",
 		Long:         ``,
 		SilenceUsage: true,
 		Example:      examples(kind),
@@ -119,5 +119,6 @@ func (opts *options) name() string {
 }
 
 func examples(kind string) string {
-	return strings.ReplaceAll(cmdExamples, "%s", kind)
+	replacer := strings.NewReplacer("%s", kind, "%S", strings.Title(kind))
+	return replacer.Replace(cmdExamples)
 }

--- a/api/pkg/cli/cmd/get/get_test.go
+++ b/api/pkg/cli/cmd/get/get_test.go
@@ -27,7 +27,17 @@ import (
 	"gotest.tools/v3/golden"
 )
 
-const api string = "http://test.hub.cli"
+var want string = `
+Get a Abc of name 'foo':
+
+    tkn hub get abc foo
+
+or
+
+Get a Abc of name 'foo' of version '0.3':
+
+    tkn hub get abc foo --version 0.3
+`
 
 var resource = &res.Resource{
 	ID:   1,
@@ -211,4 +221,9 @@ func TestGet_ResourceNotFound(t *testing.T) {
 	assert.Error(t, err)
 	assert.EqualError(t, err, "No Resource Found")
 	assert.Equal(t, gock.IsDone(), true)
+}
+
+func Test_examples(t *testing.T) {
+	got := examples("abc")
+	assert.Equal(t, want, got)
 }


### PR DESCRIPTION
This updates cmd examples to have Tekton Resource with first letter capital
in doc to follow similar approach as followed in tkn CLI.

Closes: #124

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

