### PR TITLE
CLI: Adds reinstall command

### DIFF
--- a/api/pkg/cli/cmd/reinstall/reinstall.go
+++ b/api/pkg/cli/cmd/reinstall/reinstall.go
@@ -1,0 +1,243 @@
+// Copyright © 2020 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reinstall
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/tektoncd/hub/api/pkg/cli/app"
+	"github.com/tektoncd/hub/api/pkg/cli/flag"
+	"github.com/tektoncd/hub/api/pkg/cli/hub"
+	"github.com/tektoncd/hub/api/pkg/cli/installer"
+	"github.com/tektoncd/hub/api/pkg/cli/kube"
+	"github.com/tektoncd/hub/api/pkg/cli/printer"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const (
+	defaultCatalog = "tekton"
+	catalogLabel   = "hub.tekton.dev/catalog"
+	versionLabel   = "app.kubernetes.io/version"
+)
+
+type options struct {
+	cli      app.CLI
+	from     string
+	version  string
+	kind     string
+	args     []string
+	kc       kube.Config
+	cs       kube.ClientSet
+	hubRes   hub.ResourceResult
+	resource *unstructured.Unstructured
+}
+
+var cmdExamples string = `
+Reinstall a %S of name 'foo':
+
+    tkn hub reinstall %s foo
+
+`
+
+func Command(cli app.CLI) *cobra.Command {
+
+	opts := &options{cli: cli}
+
+	cmd := &cobra.Command{
+		Use:   "reinstall",
+		Short: "Reinstall a resource by its kind and name",
+		Long:  ``,
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(
+		commandForKind("task", opts),
+	)
+
+	cmd.PersistentFlags().StringVar(&opts.from, "from", defaultCatalog, "Name of Catalog to which resource belongs.")
+	cmd.PersistentFlags().StringVar(&opts.version, "version", "", "Version of Resource")
+
+	cmd.PersistentFlags().StringVarP(&opts.kc.Path, "kubeconfig", "k", "", "Kubectl config file (default: $HOME/.kube/config)")
+	cmd.PersistentFlags().StringVarP(&opts.kc.Context, "context", "c", "", "Name of the kubeconfig context to use (default: kubectl config current-context)")
+	cmd.PersistentFlags().StringVarP(&opts.kc.Namespace, "namespace", "n", "", "Namespace to use (default: from $KUBECONFIG)")
+
+	return cmd
+}
+
+// commandForKind creates a cobra.Command that when run sets
+// opts.Kind and opts.Args and invokes opts.run
+func commandForKind(kind string, opts *options) *cobra.Command {
+
+	return &cobra.Command{
+		Use:          kind,
+		Short:        "Reinstall " + kind + " from its name",
+		Long:         ``,
+		SilenceUsage: true,
+		Example:      examples(kind),
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.kind = kind
+			opts.args = args
+			return opts.run()
+		},
+	}
+}
+
+func (opts *options) run() error {
+
+	if err := opts.validate(); err != nil {
+		return err
+	}
+
+	// This allows fake clients to be inserted while testing
+	var err error
+	if opts.cs == nil {
+		opts.cs, err = kube.NewClientSet(opts.kc)
+		if err != nil {
+			return err
+		}
+	}
+
+	installer := installer.New(opts.cs)
+	opts.resource, err = installer.LookupInstalled(opts.name(), opts.kind, opts.cs.Namespace())
+	if err != nil {
+		if err = opts.lookupError(err); err != nil {
+			return err
+		}
+	}
+
+	hubClient := opts.cli.Hub()
+	opts.hubRes = hubClient.GetResource(hub.ResourceOption{
+		Name:    opts.name(),
+		Catalog: opts.resCatalog(),
+		Kind:    opts.kind,
+		Version: opts.resVersion(),
+	})
+
+	manifest, err := opts.hubRes.Manifest()
+	if err != nil {
+		return err
+	}
+
+	opts.resource, err = installer.Update(manifest, opts.from, opts.cs.Namespace())
+	if err != nil {
+		return opts.errors(err)
+	}
+
+	out := opts.cli.Stream().Out
+	return printer.New(out).String(msg(opts.resource))
+}
+
+func msg(res *unstructured.Unstructured) string {
+	version := res.GetLabels()["app.kubernetes.io/version"]
+	return fmt.Sprintf("%s %s(%s) reinstalled in %s namespace",
+		strings.Title(res.GetKind()), res.GetName(), version, res.GetNamespace())
+}
+
+func (opts *options) validate() error {
+	return flag.ValidateVersion(opts.version)
+}
+
+func (opts *options) name() string {
+	return strings.TrimSpace(opts.args[0])
+}
+
+func (opts *options) lookupError(err error) error {
+
+	switch err {
+	case installer.ErrNotFound:
+		return fmt.Errorf("%s %s doesn't exists in %s namespace. Use install command to install the resource",
+			strings.Title(opts.kind), opts.name(), opts.cs.Namespace())
+
+	case installer.ErrVersionAndCatalogMissing:
+		if opts.version == "" {
+			return fmt.Errorf("existing resource seems to be missing version and catalog label. Use --version & --catalog (Default: tekton) flag to reinstall the resource")
+		}
+		return nil
+
+	case installer.ErrVersionMissing:
+		if opts.version == "" {
+			return fmt.Errorf("existing resource seems to be missing version label. Use --version flag to reinstall the resource")
+		}
+		return nil
+
+	// Skip catalog missing error and use default catalog
+	case installer.ErrCatalogMissing:
+		return nil
+
+	default:
+		return err
+	}
+}
+
+func (opts *options) errors(err error) error {
+
+	if err == installer.ErrNotFound {
+		return fmt.Errorf("%s %s doesn't exists in %s namespace. Use install command to install the resource",
+			strings.Title(opts.kind), opts.name(), opts.cs.Namespace())
+	}
+
+	if strings.Contains(err.Error(), "mutation failed: cannot decode incoming new object") {
+		version, vErr := opts.hubRes.MinPipelinesVersion()
+		if vErr != nil {
+			return vErr
+		}
+		return fmt.Errorf("%v \nMake sure the pipeline version you are running is not lesser than %s and %s have correct spec fields",
+			err, version, opts.kind)
+	}
+	return err
+}
+
+func (opts *options) resCatalog() string {
+	labels := opts.resource.GetLabels()
+	if len(labels) == 0 {
+		return opts.from
+	}
+	catalog, ok := labels[catalogLabel]
+	if ok {
+		if catalog != opts.from && opts.from != "" {
+			return opts.from
+		}
+		return catalog
+	}
+	return opts.from
+}
+
+func (opts *options) resVersion() string {
+	labels := opts.resource.GetLabels()
+	if len(labels) == 0 {
+		return opts.version
+	}
+	version, ok := labels[versionLabel]
+	if ok {
+		if version != opts.version && opts.version != "" {
+			return opts.version
+		}
+		return version
+	}
+	return opts.version
+}
+
+func examples(kind string) string {
+	replacer := strings.NewReplacer("%s", kind, "%S", strings.Title(kind))
+	return replacer.Replace(cmdExamples)
+}

--- a/api/pkg/cli/cmd/reinstall/reinstall_test.go
+++ b/api/pkg/cli/cmd/reinstall/reinstall_test.go
@@ -1,0 +1,287 @@
+// Copyright © 2020 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reinstall
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	res "github.com/tektoncd/hub/api/gen/resource"
+	"github.com/tektoncd/hub/api/pkg/cli/test"
+	cb "github.com/tektoncd/hub/api/pkg/cli/test/builder"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	pipelinev1beta1test "github.com/tektoncd/pipeline/test"
+	"gopkg.in/h2non/gock.v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic/fake"
+)
+
+var resVersion = &res.ResourceVersionData{
+	ID:                  11,
+	Version:             "0.3",
+	DisplayName:         "foo-bar",
+	Description:         "v0.3 Task to run foo",
+	MinPipelinesVersion: "0.12",
+	RawURL:              "http://raw.github.url/foo/0.3/foo.yaml",
+	WebURL:              "http://web.github.com/foo/0.3/foo.yaml",
+	UpdatedAt:           "2020-01-01 12:00:00 +0000 UTC",
+	Resource: &res.ResourceData{
+		ID:   1,
+		Name: "foo",
+		Kind: "Task",
+		Catalog: &res.Catalog{
+			ID:   1,
+			Name: "tekton",
+			Type: "community",
+		},
+		Rating: 4.8,
+		Tags: []*res.Tag{
+			&res.Tag{
+				ID:   3,
+				Name: "cli",
+			},
+		},
+	},
+}
+
+func TestReinstall_ResourceNotExist(t *testing.T) {
+	cli := test.NewCLI()
+
+	version := "v1beta1"
+	dynamic := fake.NewSimpleDynamicClient(runtime.NewScheme())
+
+	cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{})
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"task"})
+
+	opts := &options{
+		cs:   test.FakeClientSet(cs.Pipeline, dynamic, "hub"),
+		cli:  cli,
+		kind: "task",
+		args: []string{"foo"},
+	}
+
+	err := opts.run()
+	assert.Error(t, err)
+	assert.EqualError(t, err, "Task foo doesn't exists in hub namespace. Use install command to install the resource")
+}
+
+func TestReinstall_VersionCatalogMissing(t *testing.T) {
+	cli := test.NewCLI()
+
+	existingTask := &v1beta1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "hub",
+		},
+	}
+
+	version := "v1beta1"
+	dynamic := fake.NewSimpleDynamicClient(runtime.NewScheme(), cb.UnstructuredV1beta1T(existingTask, version))
+
+	cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{Tasks: []*v1beta1.Task{existingTask}})
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"task"})
+
+	opts := &options{
+		cs:   test.FakeClientSet(cs.Pipeline, dynamic, "hub"),
+		cli:  cli,
+		kind: "task",
+		args: []string{"foo"},
+	}
+
+	err := opts.run()
+	assert.Error(t, err)
+	assert.EqualError(t, err, "existing resource seems to be missing version and catalog label. Use --version & --catalog (Default: tekton) flag to reinstall the resource")
+}
+
+func TestReinstall_VersionMissing(t *testing.T) {
+	cli := test.NewCLI()
+
+	existingTask := &v1beta1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "hub",
+			Labels:    map[string]string{"hub.tekton.dev/catalog": "abc"},
+		},
+	}
+
+	version := "v1beta1"
+	dynamic := fake.NewSimpleDynamicClient(runtime.NewScheme(), cb.UnstructuredV1beta1T(existingTask, version))
+
+	cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{Tasks: []*v1beta1.Task{existingTask}})
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"task"})
+
+	opts := &options{
+		cs:   test.FakeClientSet(cs.Pipeline, dynamic, "hub"),
+		cli:  cli,
+		kind: "task",
+		args: []string{"foo"},
+	}
+
+	err := opts.run()
+	assert.Error(t, err)
+	assert.EqualError(t, err, "existing resource seems to be missing version label. Use --version flag to reinstall the resource")
+}
+
+func TestReinstall_DifferentVersionPassedByFlag(t *testing.T) {
+	cli := test.NewCLI()
+
+	defer gock.Off()
+
+	resVersion := &res.ResourceVersion{Data: resVersion}
+	res := res.NewViewedResourceVersion(resVersion, "default")
+	gock.New(test.API).
+		Get("/resource/tekton/task/foo/0.3").
+		Reply(200).
+		JSON(&res.Projected)
+
+	gock.New("http://raw.github.url").
+		Get("/foo/0.3/foo.yaml").
+		Reply(200).
+		File("./testdata/foo-v0.3.yaml")
+
+	buf := new(bytes.Buffer)
+	cli.SetStream(buf, buf)
+
+	existingTask := &v1beta1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "hub",
+			Labels:    map[string]string{"app.kubernetes.io/version": "0.1"},
+		},
+	}
+
+	version := "v1beta1"
+	dynamic := fake.NewSimpleDynamicClient(runtime.NewScheme(), cb.UnstructuredV1beta1T(existingTask, version))
+
+	cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{Tasks: []*v1beta1.Task{existingTask}})
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"task"})
+
+	opts := &options{
+		cs:      test.FakeClientSet(cs.Pipeline, dynamic, "hub"),
+		cli:     cli,
+		kind:    "task",
+		args:    []string{"foo"},
+		from:    "tekton",
+		version: "0.3",
+	}
+
+	err := opts.run()
+	assert.NoError(t, err)
+	assert.Equal(t, "Task foo(0.3) reinstalled in hub namespace\n", buf.String())
+	assert.Equal(t, gock.IsDone(), true)
+}
+
+func TestReinstall_DifferentCatalogPassedByFlag(t *testing.T) {
+	cli := test.NewCLI()
+
+	defer gock.Off()
+
+	resVersion := &res.ResourceVersion{Data: resVersion}
+	res := res.NewViewedResourceVersion(resVersion, "default")
+	gock.New(test.API).
+		Get("/resource/tekton/task/foo/0.3").
+		Reply(200).
+		JSON(&res.Projected)
+
+	gock.New("http://raw.github.url").
+		Get("/foo/0.3/foo.yaml").
+		Reply(200).
+		File("./testdata/foo-v0.3.yaml")
+
+	buf := new(bytes.Buffer)
+	cli.SetStream(buf, buf)
+
+	existingTask := &v1beta1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "hub",
+			Labels: map[string]string{
+				"hub.tekton.dev/catalog":    "abc",
+				"app.kubernetes.io/version": "0.1",
+			},
+		},
+	}
+
+	version := "v1beta1"
+	dynamic := fake.NewSimpleDynamicClient(runtime.NewScheme(), cb.UnstructuredV1beta1T(existingTask, version))
+
+	cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{Tasks: []*v1beta1.Task{existingTask}})
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"task"})
+
+	opts := &options{
+		cs:      test.FakeClientSet(cs.Pipeline, dynamic, "hub"),
+		cli:     cli,
+		kind:    "task",
+		args:    []string{"foo"},
+		from:    "tekton",
+		version: "0.3",
+	}
+
+	err := opts.run()
+	assert.NoError(t, err)
+	assert.Equal(t, "Task foo(0.3) reinstalled in hub namespace\n", buf.String())
+	assert.Equal(t, gock.IsDone(), true)
+}
+
+func TestReinstall(t *testing.T) {
+	cli := test.NewCLI()
+
+	defer gock.Off()
+
+	resVersion := &res.ResourceVersion{Data: resVersion}
+	res := res.NewViewedResourceVersion(resVersion, "default")
+	gock.New(test.API).
+		Get("/resource/tekton/task/foo/0.3").
+		Reply(200).
+		JSON(&res.Projected)
+
+	gock.New("http://raw.github.url").
+		Get("/foo/0.3/foo.yaml").
+		Reply(200).
+		File("./testdata/foo-v0.3.yaml")
+
+	buf := new(bytes.Buffer)
+	cli.SetStream(buf, buf)
+
+	existingTask := &v1beta1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "hub",
+			Labels: map[string]string{
+				"hub.tekton.dev/catalog":    "tekton",
+				"app.kubernetes.io/version": "0.3",
+			}},
+	}
+
+	version := "v1beta1"
+	dynamic := fake.NewSimpleDynamicClient(runtime.NewScheme(), cb.UnstructuredV1beta1T(existingTask, version))
+
+	cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{Tasks: []*v1beta1.Task{existingTask}})
+	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"task"})
+
+	opts := &options{
+		cs:   test.FakeClientSet(cs.Pipeline, dynamic, "hub"),
+		cli:  cli,
+		kind: "task",
+		args: []string{"foo"},
+	}
+
+	err := opts.run()
+	assert.NoError(t, err)
+	assert.Equal(t, "Task foo(0.3) reinstalled in hub namespace\n", buf.String())
+	assert.Equal(t, gock.IsDone(), true)
+}

--- a/api/pkg/cli/cmd/reinstall/testdata/foo-v0.3.yaml
+++ b/api/pkg/cli/cmd/reinstall/testdata/foo-v0.3.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: foo
+  labels:
+    app.kubernetes.io/version: '0.3'
+  annotations:
+    tekton.dev/pipelines.minVersion: '0.13.1'
+    tekton.dev/tags: cli
+    tekton.dev/displayName: 'foo-bar'
+spec:
+  description: >-
+    v0.3 Task to run foo

--- a/api/pkg/cli/cmd/root.go
+++ b/api/pkg/cli/cmd/root.go
@@ -20,6 +20,7 @@ import (
 	"github.com/tektoncd/hub/api/pkg/cli/cmd/get"
 	"github.com/tektoncd/hub/api/pkg/cli/cmd/info"
 	"github.com/tektoncd/hub/api/pkg/cli/cmd/install"
+	"github.com/tektoncd/hub/api/pkg/cli/cmd/reinstall"
 	"github.com/tektoncd/hub/api/pkg/cli/cmd/search"
 	"github.com/tektoncd/hub/api/pkg/cli/hub"
 )
@@ -48,6 +49,7 @@ func Root(cli app.CLI) *cobra.Command {
 		get.Command(cli),
 		info.Command(cli),
 		install.Command(cli),
+		reinstall.Command(cli),
 		search.Command(cli),
 	)
 

--- a/api/pkg/cli/installer/config.go
+++ b/api/pkg/cli/installer/config.go
@@ -16,6 +16,7 @@ package installer
 
 import (
 	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/dynamic"
 )
 
@@ -25,9 +26,10 @@ type ClientSet interface {
 }
 
 type Installer struct {
-	cs ClientSet
+	cs          ClientSet
+	existingRes *unstructured.Unstructured
 }
 
 func New(cs ClientSet) *Installer {
-	return &Installer{cs}
+	return &Installer{cs, nil}
 }

--- a/api/pkg/cli/installer/kube_action.go
+++ b/api/pkg/cli/installer/kube_action.go
@@ -52,3 +52,17 @@ func (i *Installer) get(objectName, kind, namespace string, op metav1.GetOptions
 	}
 	return obj, nil
 }
+
+func (i *Installer) update(object *unstructured.Unstructured, namespace string, op metav1.UpdateOptions) (*unstructured.Unstructured, error) {
+
+	gvrObj := schema.GroupVersionResource{Group: tektonGroup, Resource: object.GetKind()}
+	gvr, err := getGroupVersionResource(gvrObj, i.cs.Tekton().Discovery())
+	if err != nil {
+		return nil, err
+	}
+	obj, err := i.cs.Dynamic().Resource(*gvr).Namespace(namespace).Update(context.Background(), object, op)
+	if err != nil {
+		return nil, err
+	}
+	return obj, nil
+}


### PR DESCRIPTION
This adds reinstall command to install an existing resource again.
If a user install Task A and then change it editing the yaml, then the
user can reinstall the same Task which will bring the Task to orignal.
tkn hub reinstall task <name> [--from=<catalog>] [--version=<version>]
If the task yaml is missing catalog or version label, user will be asked
for it.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

