### PR TITLE
UI: Adds EmptyState with title `No Resource Found`

### DIFF
--- a/ui/src/containers/Resources/Resources.css
+++ b/ui/src/containers/Resources/Resources.css
@@ -10,3 +10,7 @@
   bottom: 0;
   margin: auto;
 }
+
+.hub-resource-emptystate__margin {
+  margin-left: -12em;
+}

--- a/ui/src/containers/Resources/Resources.test.tsx
+++ b/ui/src/containers/Resources/Resources.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import { when } from 'mobx';
-import { GalleryItem } from '@patternfly/react-core';
+import { EmptyState, GalleryItem } from '@patternfly/react-core';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { FakeHub } from '../../api/testutil';
 import { createProviderAndStore } from '../../store/root';
@@ -41,6 +41,36 @@ describe('Resource Component', () => {
 
           const c = component.find(Cards);
           expect(c.find(GalleryItem).length).toBe(7);
+
+          done();
+        }, 0);
+      }
+    );
+  });
+
+  it('should find EmptyState if filtered does not match to any resources', (done) => {
+    const component = mount(
+      <Provider>
+        <Router>
+          <Resources />
+        </Router>
+      </Provider>
+    );
+
+    const { resources } = root;
+    when(
+      () => {
+        return !resources.isLoading;
+      },
+      () => {
+        setTimeout(() => {
+          resources.setSearch('asdf');
+          const resource = resources.filteredResources;
+          expect(resource.length).toBe(0);
+
+          component.update();
+          const r = component.find(EmptyState);
+          expect(r.length).toEqual(1);
 
           done();
         }, 0);

--- a/ui/src/containers/Resources/index.tsx
+++ b/ui/src/containers/Resources/index.tsx
@@ -1,24 +1,43 @@
 import React from 'react';
-import { Gallery, Spinner } from '@patternfly/react-core';
-import { useMst } from '../../store/root';
 import { useObserver } from 'mobx-react';
+import {
+  EmptyState,
+  EmptyStateIcon,
+  EmptyStateVariant,
+  Gallery,
+  Spinner,
+  Title
+} from '@patternfly/react-core';
+import CubesIcon from '@patternfly/react-icons/dist/js/icons/cubes-icon';
+import { useMst } from '../../store/root';
+import { IResource } from '../../store/resource';
 import Cards from '../../components/Cards';
 import './Resources.css';
 
 const Resources = () => {
   const { resources } = useMst();
 
+  const checkResources = (resources: IResource[]) => {
+    return !resources.length ? (
+      <EmptyState variant={EmptyStateVariant.full} className="hub-resource-emptystate__margin">
+        <EmptyStateIcon icon={CubesIcon} />
+        <Title headingLevel="h5" size="md">
+          No Resource Found.
+        </Title>
+      </EmptyState>
+    ) : (
+      <Gallery hasGutter className="hub-resource">
+        <Cards items={resources} />
+      </Gallery>
+    );
+  };
+
   return useObserver(() =>
     resources.isLoading ? (
       <Spinner className="hub-spinner" />
     ) : (
-      <React.Fragment>
-        <Gallery hasGutter className="hub-resource">
-          <Cards items={resources.filteredResources} />
-        </Gallery>
-      </React.Fragment>
+      <React.Fragment>{checkResources(resources.filteredResources)}</React.Fragment>
     )
   );
 };
-
 export default Resources;


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This patch adds EmptyState with title `No Resource Found`
if selected filter doesn't match to any resources

Signed-off-by: Shiv Verma <shverma@redhat.com>

![Screenshot from 2021-01-07 17-37-22](https://user-images.githubusercontent.com/31416465/103890997-0f6b9480-510f-11eb-885e-29d454758d3d.png)


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

