### PR TITLE
Fix moment date tests

### DIFF
--- a/ui/src/components/Cards/Cards.test.tsx
+++ b/ui/src/components/Cards/Cards.test.tsx
@@ -9,6 +9,14 @@ import Cards from '.';
 const TESTDATA_DIR = `src/store/testdata`;
 const api = new FakeHub(TESTDATA_DIR);
 
+beforeEach(() => {
+  global.Date.now = jest.fn(() => new Date('2020-12-22T10:20:30Z').getTime());
+});
+
+afterEach(() => {
+  global.Date = Date;
+});
+
 describe('Cards', () => {
   it('should render the resources on cards', (done) => {
     const store = ResourceStore.create({}, { api, categories: CategoryStore.create({}, { api }) });

--- a/ui/src/containers/Resources/Resources.test.tsx
+++ b/ui/src/containers/Resources/Resources.test.tsx
@@ -12,6 +12,14 @@ const TESTDATA_DIR = `src/store/testdata`;
 const api = new FakeHub(TESTDATA_DIR);
 const { Provider, root } = createProviderAndStore(api);
 
+beforeEach(() => {
+  global.Date.now = jest.fn(() => new Date('2020-12-22T10:20:30Z').getTime());
+});
+
+afterEach(() => {
+  global.Date = Date;
+});
+
 describe('Resource Component', () => {
   it('should render the resources component', (done) => {
     const component = mount(


### PR DESCRIPTION
# Changes

Right now the snapshots used to get updated every month where time was
involved which was not a good idea.

Adds `beforeEach` and `afterEach` functions to mock the time so that the
snapshot doesn't gets updated every month and after every test recover
the date back to original date.

Signed-off-by: vinamra28 <vinjain@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

