### PR TITLE
UI: Fixes resource cards margin

### DIFF
--- a/ui/src/components/Cards/Cards.css
+++ b/ui/src/components/Cards/Cards.css
@@ -1,7 +1,6 @@
 .hub-resource-card {
   background-color: white;
   height: 23em;
-  width: 18.5em;
   color: black;
   border-radius: 0.5em;
 }


### PR DESCRIPTION
Previously margin around resource cards were not consistent
with different screen resolution and this patch fixes it

Deployed Link : https://ui-tekton-hub.apps.cluster-blr-9d7f.blr-9d7f.example.opentlc.com/

Signed-off-by: Shiv Verma <shverma@redhat>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

