### PR TITLE
Adds multi catalog support for UI

### DIFF
--- a/ui/src/components/Description/Description.test.tsx
+++ b/ui/src/components/Description/Description.test.tsx
@@ -18,8 +18,8 @@ describe('Resource Readme and Yaml', () => {
         return !resources.isLoading;
       },
       () => {
-        resources.loadReadme('buildah');
-        resources.loadYaml('buildah');
+        resources.loadReadme('tekton/Task/buildah');
+        resources.loadYaml('tekton/Task/buildah');
         when(
           () => {
             return !resources.isLoading;
@@ -28,7 +28,7 @@ describe('Resource Readme and Yaml', () => {
             setTimeout(() => {
               const component = mount(
                 <Provider>
-                  <Description name="buildah" />
+                  <Description name="buildah" catalog="tekton" kind="Task" />
                 </Provider>
               );
               component.update();

--- a/ui/src/components/Description/index.tsx
+++ b/ui/src/components/Description/index.tsx
@@ -6,10 +6,13 @@ import { Grid, Card, Tabs, Tab, GridItem, CardHeader, Spinner } from '@patternfl
 import { useMst } from '../../store/root';
 import Readme from '../Readme';
 import Yaml from '../Yaml';
+import { titleCase } from '../../common/titlecase';
 import './Description.css';
 
 interface Props {
   name: string;
+  catalog: string;
+  kind: string;
 }
 
 const Description: React.FC<Props> = (props) => {
@@ -20,7 +23,8 @@ const Description: React.FC<Props> = (props) => {
     setActiveTabKey(Number(tabIndex));
   };
 
-  const resource = resources.resources.get(props.name);
+  const { catalog, kind, name } = props;
+  const resource = resources.resources.get(`${catalog}/${titleCase(kind)}/${name}`);
 
   return useObserver(() =>
     resource.readme === '' || resource.yaml === '' ? (

--- a/ui/src/containers/BasicDetails/BasicDetails.test.tsx
+++ b/ui/src/containers/BasicDetails/BasicDetails.test.tsx
@@ -20,7 +20,9 @@ jest.mock('react-router-dom', () => {
     },
     useParams: () => {
       return {
-        name: 'buildah'
+        name: 'buildah',
+        catalog: 'tekton',
+        kind: 'Task'
       };
     }
   };
@@ -33,7 +35,7 @@ it('should render the BasicDetails component', (done) => {
       return !resources.isLoading;
     },
     () => {
-      resources.versionInfo('buildah');
+      resources.versionInfo('tekton/Task/buildah');
       when(
         () => {
           return !resources.isLoading;
@@ -66,7 +68,7 @@ it('length of DropdownItems should be 2 in case of buildah', (done) => {
       return !resources.isLoading;
     },
     () => {
-      resources.versionInfo('buildah');
+      resources.versionInfo('tekton/Task/buildah');
       when(
         () => {
           return !resources.isLoading;

--- a/ui/src/containers/BasicDetails/index.tsx
+++ b/ui/src/containers/BasicDetails/index.tsx
@@ -31,18 +31,20 @@ import { Icons } from '../../common/icons';
 import Icon from '../../components/Icon';
 import TooltipDisplay from '../../components/TooltipDisplay';
 import Rating from '../Rating';
+import { titleCase } from '../../common/titlecase';
 import './BasicDetails.css';
 
 const BasicDetails: React.FC = () => {
   const { resources } = useMst();
-  const { name } = useParams();
+  const { catalog, kind, name } = useParams();
 
-  const resource: IResource = resources.resources.get(name);
+  const resourceKey = `${catalog}/${titleCase(kind)}/${name}`;
+  const resource: IResource = resources.resources.get(resourceKey);
   const dropdownItems = resource.versions.map((value) => (
     <DropdownItem
       id={String(value.id)}
       key={value.id}
-      onClick={(e) => resources.setDisplayVersion(name, e.currentTarget.id)}
+      onClick={(e) => resources.setDisplayVersion(resourceKey, e.currentTarget.id)}
     >
       {value.version === resource.latestVersion.version
         ? `${value.version} (latest)`

--- a/ui/src/containers/Details/__snapshots__/Details.test.tsx.snap
+++ b/ui/src/containers/Details/__snapshots__/Details.test.tsx.snap
@@ -277,7 +277,7 @@ exports[`Details component should render the details component 1`] = `
         </article>
       </Card>
     </BasicDetails>
-    <Description name=\\"buildah\\">
+    <Description name=\\"buildah\\" catalog=\\"tekton\\" kind=\\"task\\">
       <Spinner className=\\"hub-details-spinner\\">
         <span className=\\"pf-c-spinner pf-m-xl hub-details-spinner\\" role=\\"progressbar\\" aria-valuetext=\\"Loading...\\">
           <span className=\\"pf-c-spinner__clipper\\" />

--- a/ui/src/containers/Details/index.tsx
+++ b/ui/src/containers/Details/index.tsx
@@ -8,28 +8,21 @@ import Description from '../../components/Description';
 import { assert } from '../../store/utils';
 import { PageNotFound } from '../../components/PageNotFound';
 import { titleCase } from '../../common/titlecase';
-import { ICatalog } from '../../store/catalog';
 
 const Details: React.FC = () => {
   const { resources, user } = useMst();
   const { name, catalog, kind } = useParams();
 
-  const catalogs = resources.catalogs.values;
+  const resourceKey = `${catalog}/${titleCase(kind)}/${name}`;
   const validateUrl = () => {
-    let catalogUrl = false;
-    catalogs.forEach((item: ICatalog) => {
-      if (item.name === catalog) catalogUrl = true;
-    });
-    return (
-      catalogUrl && resources.kinds.items.has(titleCase(kind)) && resources.resources.has(name)
-    );
+    return resources.resources.has(resourceKey);
   };
 
   const resourceDetails = () => {
-    resources.versionInfo(name);
-    resources.loadReadme(name);
-    resources.loadYaml(name);
-    const resource = resources.resources.get(name);
+    resources.versionInfo(resourceKey);
+    resources.loadReadme(resourceKey);
+    resources.loadYaml(resourceKey);
+    const resource = resources.resources.get(resourceKey);
     assert(resource);
     user.getRating(resource.id);
   };
@@ -50,7 +43,7 @@ const Details: React.FC = () => {
         {resourceDetails()}
         {scrollToTop()}
         <BasicDetails />
-        <Description name={name} />
+        <Description name={name} catalog={catalog} kind={kind} />
       </React.Fragment>
     )
   );

--- a/ui/src/store/__snapshots__/resource.test.ts.snap
+++ b/ui/src/store/__snapshots__/resource.test.ts.snap
@@ -36,79 +36,7 @@ Object {
 
 exports[`Store functions creates a resource store 1`] = `
 Object {
-  "ansible-runner": Object {
-    "catalog": 1,
-    "displayName": "Ansible Runner",
-    "displayVersion": 1,
-    "id": 1,
-    "kind": "Task",
-    "latestVersion": 1,
-    "name": "ansible-runner",
-    "rating": 4.5,
-    "readme": "",
-    "tags": Array [
-      2,
-    ],
-    "versions": Array [
-      1,
-    ],
-    "yaml": "",
-  },
-  "aws-cli": Object {
-    "catalog": 1,
-    "displayName": "aws cli",
-    "displayVersion": 4,
-    "id": 4,
-    "kind": "Task",
-    "latestVersion": 4,
-    "name": "aws-cli",
-    "rating": 5,
-    "readme": "",
-    "tags": Array [
-      2,
-    ],
-    "versions": Array [
-      4,
-    ],
-    "yaml": "",
-  },
-  "buildah": Object {
-    "catalog": 1,
-    "displayName": "",
-    "displayVersion": 105,
-    "id": 13,
-    "kind": "Task",
-    "latestVersion": 105,
-    "name": "buildah",
-    "rating": 4,
-    "readme": "",
-    "tags": Array [
-      8,
-    ],
-    "versions": Array [
-      105,
-    ],
-    "yaml": "",
-  },
-  "golang-build": Object {
-    "catalog": 1,
-    "displayName": "golang build",
-    "displayVersion": 47,
-    "id": 44,
-    "kind": "Task",
-    "latestVersion": 47,
-    "name": "golang-build",
-    "rating": 5,
-    "readme": "",
-    "tags": Array [
-      1,
-    ],
-    "versions": Array [
-      47,
-    ],
-    "yaml": "",
-  },
-  "hub": Object {
+  "tekton-hub/Pipeline/hub": Object {
     "catalog": 2,
     "displayName": "Hub Pipeline",
     "displayVersion": 1,
@@ -118,6 +46,7 @@ Object {
     "name": "hub",
     "rating": 4.5,
     "readme": "",
+    "resourceKey": "tekton-hub/Pipeline/hub",
     "tags": Array [
       10,
     ],
@@ -126,7 +55,83 @@ Object {
     ],
     "yaml": "",
   },
-  "jenkins": Object {
+  "tekton/Task/ansible-runner": Object {
+    "catalog": 1,
+    "displayName": "Ansible Runner",
+    "displayVersion": 1,
+    "id": 1,
+    "kind": "Task",
+    "latestVersion": 1,
+    "name": "ansible-runner",
+    "rating": 4.5,
+    "readme": "",
+    "resourceKey": "tekton/Task/ansible-runner",
+    "tags": Array [
+      2,
+    ],
+    "versions": Array [
+      1,
+    ],
+    "yaml": "",
+  },
+  "tekton/Task/aws-cli": Object {
+    "catalog": 1,
+    "displayName": "aws cli",
+    "displayVersion": 4,
+    "id": 4,
+    "kind": "Task",
+    "latestVersion": 4,
+    "name": "aws-cli",
+    "rating": 5,
+    "readme": "",
+    "resourceKey": "tekton/Task/aws-cli",
+    "tags": Array [
+      2,
+    ],
+    "versions": Array [
+      4,
+    ],
+    "yaml": "",
+  },
+  "tekton/Task/buildah": Object {
+    "catalog": 1,
+    "displayName": "",
+    "displayVersion": 105,
+    "id": 13,
+    "kind": "Task",
+    "latestVersion": 105,
+    "name": "buildah",
+    "rating": 4,
+    "readme": "",
+    "resourceKey": "tekton/Task/buildah",
+    "tags": Array [
+      8,
+    ],
+    "versions": Array [
+      105,
+    ],
+    "yaml": "",
+  },
+  "tekton/Task/golang-build": Object {
+    "catalog": 1,
+    "displayName": "golang build",
+    "displayVersion": 47,
+    "id": 44,
+    "kind": "Task",
+    "latestVersion": 47,
+    "name": "golang-build",
+    "rating": 5,
+    "readme": "",
+    "resourceKey": "tekton/Task/golang-build",
+    "tags": Array [
+      1,
+    ],
+    "versions": Array [
+      47,
+    ],
+    "yaml": "",
+  },
+  "tekton/Task/jenkins": Object {
     "catalog": 1,
     "displayName": "jenkins operation",
     "displayVersion": 104,
@@ -136,6 +141,7 @@ Object {
     "name": "jenkins",
     "rating": 5,
     "readme": "",
+    "resourceKey": "tekton/Task/jenkins",
     "tags": Array [
       57,
       56,
@@ -145,7 +151,7 @@ Object {
     ],
     "yaml": "",
   },
-  "jib-maven": Object {
+  "tekton/Task/jib-maven": Object {
     "catalog": 1,
     "displayName": "jib maven",
     "displayVersion": 57,
@@ -155,6 +161,7 @@ Object {
     "name": "jib-maven",
     "rating": 5,
     "readme": "",
+    "resourceKey": "tekton/Task/jib-maven",
     "tags": Array [
       8,
     ],
@@ -168,79 +175,7 @@ Object {
 
 exports[`Store functions fetch 0.1 version details for buildah resource 1`] = `
 Object {
-  "ansible-runner": Object {
-    "catalog": 1,
-    "displayName": "Ansible Runner",
-    "displayVersion": 1,
-    "id": 1,
-    "kind": "Task",
-    "latestVersion": 1,
-    "name": "ansible-runner",
-    "rating": 4.5,
-    "readme": "",
-    "tags": Array [
-      2,
-    ],
-    "versions": Array [
-      1,
-    ],
-    "yaml": "",
-  },
-  "aws-cli": Object {
-    "catalog": 1,
-    "displayName": "aws cli",
-    "displayVersion": 4,
-    "id": 4,
-    "kind": "Task",
-    "latestVersion": 4,
-    "name": "aws-cli",
-    "rating": 5,
-    "readme": "",
-    "tags": Array [
-      2,
-    ],
-    "versions": Array [
-      4,
-    ],
-    "yaml": "",
-  },
-  "buildah": Object {
-    "catalog": 1,
-    "displayName": "",
-    "displayVersion": 105,
-    "id": 13,
-    "kind": "Task",
-    "latestVersion": 105,
-    "name": "buildah",
-    "rating": 4,
-    "readme": "",
-    "tags": Array [
-      8,
-    ],
-    "versions": Array [
-      105,
-    ],
-    "yaml": "",
-  },
-  "golang-build": Object {
-    "catalog": 1,
-    "displayName": "golang build",
-    "displayVersion": 47,
-    "id": 44,
-    "kind": "Task",
-    "latestVersion": 47,
-    "name": "golang-build",
-    "rating": 5,
-    "readme": "",
-    "tags": Array [
-      1,
-    ],
-    "versions": Array [
-      47,
-    ],
-    "yaml": "",
-  },
-  "hub": Object {
+  "tekton-hub/Pipeline/hub": Object {
     "catalog": 2,
     "displayName": "Hub Pipeline",
     "displayVersion": 1,
@@ -250,6 +185,7 @@ Object {
     "name": "hub",
     "rating": 4.5,
     "readme": "",
+    "resourceKey": "tekton-hub/Pipeline/hub",
     "tags": Array [
       10,
     ],
@@ -258,7 +194,83 @@ Object {
     ],
     "yaml": "",
   },
-  "jenkins": Object {
+  "tekton/Task/ansible-runner": Object {
+    "catalog": 1,
+    "displayName": "Ansible Runner",
+    "displayVersion": 1,
+    "id": 1,
+    "kind": "Task",
+    "latestVersion": 1,
+    "name": "ansible-runner",
+    "rating": 4.5,
+    "readme": "",
+    "resourceKey": "tekton/Task/ansible-runner",
+    "tags": Array [
+      2,
+    ],
+    "versions": Array [
+      1,
+    ],
+    "yaml": "",
+  },
+  "tekton/Task/aws-cli": Object {
+    "catalog": 1,
+    "displayName": "aws cli",
+    "displayVersion": 4,
+    "id": 4,
+    "kind": "Task",
+    "latestVersion": 4,
+    "name": "aws-cli",
+    "rating": 5,
+    "readme": "",
+    "resourceKey": "tekton/Task/aws-cli",
+    "tags": Array [
+      2,
+    ],
+    "versions": Array [
+      4,
+    ],
+    "yaml": "",
+  },
+  "tekton/Task/buildah": Object {
+    "catalog": 1,
+    "displayName": "",
+    "displayVersion": 105,
+    "id": 13,
+    "kind": "Task",
+    "latestVersion": 105,
+    "name": "buildah",
+    "rating": 4,
+    "readme": "",
+    "resourceKey": "tekton/Task/buildah",
+    "tags": Array [
+      8,
+    ],
+    "versions": Array [
+      105,
+    ],
+    "yaml": "",
+  },
+  "tekton/Task/golang-build": Object {
+    "catalog": 1,
+    "displayName": "golang build",
+    "displayVersion": 47,
+    "id": 44,
+    "kind": "Task",
+    "latestVersion": 47,
+    "name": "golang-build",
+    "rating": 5,
+    "readme": "",
+    "resourceKey": "tekton/Task/golang-build",
+    "tags": Array [
+      1,
+    ],
+    "versions": Array [
+      47,
+    ],
+    "yaml": "",
+  },
+  "tekton/Task/jenkins": Object {
     "catalog": 1,
     "displayName": "jenkins operation",
     "displayVersion": 104,
@@ -268,6 +280,7 @@ Object {
     "name": "jenkins",
     "rating": 5,
     "readme": "",
+    "resourceKey": "tekton/Task/jenkins",
     "tags": Array [
       57,
       56,
@@ -277,7 +290,7 @@ Object {
     ],
     "yaml": "",
   },
-  "jib-maven": Object {
+  "tekton/Task/jib-maven": Object {
     "catalog": 1,
     "displayName": "jib maven",
     "displayVersion": 57,
@@ -287,6 +300,165 @@ Object {
     "name": "jib-maven",
     "rating": 5,
     "readme": "",
+    "resourceKey": "tekton/Task/jib-maven",
+    "tags": Array [
+      8,
+    ],
+    "versions": Array [
+      57,
+    ],
+    "yaml": "",
+  },
+}
+`;
+
+exports[`Store functions makes sure to add resources with same name but from different catalog 1`] = `
+Object {
+  "tekton-hub/Pipeline/hub": Object {
+    "catalog": 2,
+    "displayName": "Hub Pipeline",
+    "displayVersion": 1,
+    "id": 10,
+    "kind": "Pipeline",
+    "latestVersion": 1,
+    "name": "hub",
+    "rating": 4.5,
+    "readme": "",
+    "resourceKey": "tekton-hub/Pipeline/hub",
+    "tags": Array [
+      10,
+    ],
+    "versions": Array [
+      1,
+    ],
+    "yaml": "",
+  },
+  "tekton-hub/Task/golang-build": Object {
+    "catalog": 2,
+    "displayName": "golang build",
+    "displayVersion": 47,
+    "id": 44,
+    "kind": "Task",
+    "latestVersion": 47,
+    "name": "golang-build",
+    "rating": 5,
+    "readme": "",
+    "resourceKey": "tekton-hub/Task/golang-build",
+    "tags": Array [
+      1,
+    ],
+    "versions": Array [
+      47,
+    ],
+    "yaml": "",
+  },
+  "tekton/Task/ansible-runner": Object {
+    "catalog": 1,
+    "displayName": "Ansible Runner",
+    "displayVersion": 1,
+    "id": 1,
+    "kind": "Task",
+    "latestVersion": 1,
+    "name": "ansible-runner",
+    "rating": 4.5,
+    "readme": "",
+    "resourceKey": "tekton/Task/ansible-runner",
+    "tags": Array [
+      2,
+    ],
+    "versions": Array [
+      1,
+    ],
+    "yaml": "",
+  },
+  "tekton/Task/aws-cli": Object {
+    "catalog": 1,
+    "displayName": "aws cli",
+    "displayVersion": 4,
+    "id": 4,
+    "kind": "Task",
+    "latestVersion": 4,
+    "name": "aws-cli",
+    "rating": 5,
+    "readme": "",
+    "resourceKey": "tekton/Task/aws-cli",
+    "tags": Array [
+      2,
+    ],
+    "versions": Array [
+      4,
+    ],
+    "yaml": "",
+  },
+  "tekton/Task/buildah": Object {
+    "catalog": 1,
+    "displayName": "",
+    "displayVersion": 105,
+    "id": 13,
+    "kind": "Task",
+    "latestVersion": 105,
+    "name": "buildah",
+    "rating": 4,
+    "readme": "",
+    "resourceKey": "tekton/Task/buildah",
+    "tags": Array [
+      8,
+    ],
+    "versions": Array [
+      105,
+    ],
+    "yaml": "",
+  },
+  "tekton/Task/golang-build": Object {
+    "catalog": 1,
+    "displayName": "golang build",
+    "displayVersion": 47,
+    "id": 44,
+    "kind": "Task",
+    "latestVersion": 47,
+    "name": "golang-build",
+    "rating": 5,
+    "readme": "",
+    "resourceKey": "tekton/Task/golang-build",
+    "tags": Array [
+      1,
+    ],
+    "versions": Array [
+      47,
+    ],
+    "yaml": "",
+  },
+  "tekton/Task/jenkins": Object {
+    "catalog": 1,
+    "displayName": "jenkins operation",
+    "displayVersion": 104,
+    "id": 98,
+    "kind": "Task",
+    "latestVersion": 104,
+    "name": "jenkins",
+    "rating": 5,
+    "readme": "",
+    "resourceKey": "tekton/Task/jenkins",
+    "tags": Array [
+      57,
+      56,
+    ],
+    "versions": Array [
+      104,
+    ],
+    "yaml": "",
+  },
+  "tekton/Task/jib-maven": Object {
+    "catalog": 1,
+    "displayName": "jib maven",
+    "displayVersion": 57,
+    "id": 54,
+    "kind": "Task",
+    "latestVersion": 57,
+    "name": "jib-maven",
+    "rating": 5,
+    "readme": "",
+    "resourceKey": "tekton/Task/jib-maven",
     "tags": Array [
       8,
     ],
@@ -300,79 +472,7 @@ Object {
 
 exports[`Store functions makes sure to not add duplicate resources 1`] = `
 Object {
-  "ansible-runner": Object {
-    "catalog": 1,
-    "displayName": "Ansible Runner",
-    "displayVersion": 1,
-    "id": 1,
-    "kind": "Task",
-    "latestVersion": 1,
-    "name": "ansible-runner",
-    "rating": 4.5,
-    "readme": "",
-    "tags": Array [
-      2,
-    ],
-    "versions": Array [
-      1,
-    ],
-    "yaml": "",
-  },
-  "aws-cli": Object {
-    "catalog": 1,
-    "displayName": "aws cli",
-    "displayVersion": 4,
-    "id": 4,
-    "kind": "Task",
-    "latestVersion": 4,
-    "name": "aws-cli",
-    "rating": 5,
-    "readme": "",
-    "tags": Array [
-      2,
-    ],
-    "versions": Array [
-      4,
-    ],
-    "yaml": "",
-  },
-  "buildah": Object {
-    "catalog": 1,
-    "displayName": "",
-    "displayVersion": 105,
-    "id": 13,
-    "kind": "Task",
-    "latestVersion": 105,
-    "name": "buildah",
-    "rating": 4,
-    "readme": "",
-    "tags": Array [
-      8,
-    ],
-    "versions": Array [
-      105,
-    ],
-    "yaml": "",
-  },
-  "golang-build": Object {
-    "catalog": 1,
-    "displayName": "golang build",
-    "displayVersion": 47,
-    "id": 44,
-    "kind": "Task",
-    "latestVersion": 47,
-    "name": "golang-build",
-    "rating": 5,
-    "readme": "",
-    "tags": Array [
-      1,
-    ],
-    "versions": Array [
-      47,
-    ],
-    "yaml": "",
-  },
-  "hub": Object {
+  "tekton-hub/Pipeline/hub": Object {
     "catalog": 2,
     "displayName": "Hub Pipeline",
     "displayVersion": 1,
@@ -382,6 +482,7 @@ Object {
     "name": "hub",
     "rating": 4.5,
     "readme": "",
+    "resourceKey": "tekton-hub/Pipeline/hub",
     "tags": Array [
       10,
     ],
@@ -390,7 +491,83 @@ Object {
     ],
     "yaml": "",
   },
-  "jenkins": Object {
+  "tekton/Task/ansible-runner": Object {
+    "catalog": 1,
+    "displayName": "Ansible Runner",
+    "displayVersion": 1,
+    "id": 1,
+    "kind": "Task",
+    "latestVersion": 1,
+    "name": "ansible-runner",
+    "rating": 4.5,
+    "readme": "",
+    "resourceKey": "tekton/Task/ansible-runner",
+    "tags": Array [
+      2,
+    ],
+    "versions": Array [
+      1,
+    ],
+    "yaml": "",
+  },
+  "tekton/Task/aws-cli": Object {
+    "catalog": 1,
+    "displayName": "aws cli",
+    "displayVersion": 4,
+    "id": 4,
+    "kind": "Task",
+    "latestVersion": 4,
+    "name": "aws-cli",
+    "rating": 5,
+    "readme": "",
+    "resourceKey": "tekton/Task/aws-cli",
+    "tags": Array [
+      2,
+    ],
+    "versions": Array [
+      4,
+    ],
+    "yaml": "",
+  },
+  "tekton/Task/buildah": Object {
+    "catalog": 1,
+    "displayName": "",
+    "displayVersion": 105,
+    "id": 13,
+    "kind": "Task",
+    "latestVersion": 105,
+    "name": "buildah",
+    "rating": 4,
+    "readme": "",
+    "resourceKey": "tekton/Task/buildah",
+    "tags": Array [
+      8,
+    ],
+    "versions": Array [
+      105,
+    ],
+    "yaml": "",
+  },
+  "tekton/Task/golang-build": Object {
+    "catalog": 1,
+    "displayName": "golang build",
+    "displayVersion": 47,
+    "id": 44,
+    "kind": "Task",
+    "latestVersion": 47,
+    "name": "golang-build",
+    "rating": 5,
+    "readme": "",
+    "resourceKey": "tekton/Task/golang-build",
+    "tags": Array [
+      1,
+    ],
+    "versions": Array [
+      47,
+    ],
+    "yaml": "",
+  },
+  "tekton/Task/jenkins": Object {
     "catalog": 1,
     "displayName": "jenkins operation",
     "displayVersion": 104,
@@ -400,6 +577,7 @@ Object {
     "name": "jenkins",
     "rating": 5,
     "readme": "",
+    "resourceKey": "tekton/Task/jenkins",
     "tags": Array [
       57,
       56,
@@ -409,7 +587,7 @@ Object {
     ],
     "yaml": "",
   },
-  "jib-maven": Object {
+  "tekton/Task/jib-maven": Object {
     "catalog": 1,
     "displayName": "jib maven",
     "displayVersion": 57,
@@ -419,6 +597,7 @@ Object {
     "name": "jib-maven",
     "rating": 5,
     "readme": "",
+    "resourceKey": "tekton/Task/jib-maven",
     "tags": Array [
       8,
     ],
@@ -432,79 +611,7 @@ Object {
 
 exports[`Store functions set 0.1 as display version for buildah 1`] = `
 Object {
-  "ansible-runner": Object {
-    "catalog": 1,
-    "displayName": "Ansible Runner",
-    "displayVersion": 1,
-    "id": 1,
-    "kind": "Task",
-    "latestVersion": 1,
-    "name": "ansible-runner",
-    "rating": 4.5,
-    "readme": "",
-    "tags": Array [
-      2,
-    ],
-    "versions": Array [
-      1,
-    ],
-    "yaml": "",
-  },
-  "aws-cli": Object {
-    "catalog": 1,
-    "displayName": "aws cli",
-    "displayVersion": 4,
-    "id": 4,
-    "kind": "Task",
-    "latestVersion": 4,
-    "name": "aws-cli",
-    "rating": 5,
-    "readme": "",
-    "tags": Array [
-      2,
-    ],
-    "versions": Array [
-      4,
-    ],
-    "yaml": "",
-  },
-  "buildah": Object {
-    "catalog": 1,
-    "displayName": "",
-    "displayVersion": 105,
-    "id": 13,
-    "kind": "Task",
-    "latestVersion": 105,
-    "name": "buildah",
-    "rating": 4,
-    "readme": "",
-    "tags": Array [
-      8,
-    ],
-    "versions": Array [
-      105,
-    ],
-    "yaml": "",
-  },
-  "golang-build": Object {
-    "catalog": 1,
-    "displayName": "golang build",
-    "displayVersion": 47,
-    "id": 44,
-    "kind": "Task",
-    "latestVersion": 47,
-    "name": "golang-build",
-    "rating": 5,
-    "readme": "",
-    "tags": Array [
-      1,
-    ],
-    "versions": Array [
-      47,
-    ],
-    "yaml": "",
-  },
-  "hub": Object {
+  "tekton-hub/Pipeline/hub": Object {
     "catalog": 2,
     "displayName": "Hub Pipeline",
     "displayVersion": 1,
@@ -514,6 +621,7 @@ Object {
     "name": "hub",
     "rating": 4.5,
     "readme": "",
+    "resourceKey": "tekton-hub/Pipeline/hub",
     "tags": Array [
       10,
     ],
@@ -522,7 +630,83 @@ Object {
     ],
     "yaml": "",
   },
-  "jenkins": Object {
+  "tekton/Task/ansible-runner": Object {
+    "catalog": 1,
+    "displayName": "Ansible Runner",
+    "displayVersion": 1,
+    "id": 1,
+    "kind": "Task",
+    "latestVersion": 1,
+    "name": "ansible-runner",
+    "rating": 4.5,
+    "readme": "",
+    "resourceKey": "tekton/Task/ansible-runner",
+    "tags": Array [
+      2,
+    ],
+    "versions": Array [
+      1,
+    ],
+    "yaml": "",
+  },
+  "tekton/Task/aws-cli": Object {
+    "catalog": 1,
+    "displayName": "aws cli",
+    "displayVersion": 4,
+    "id": 4,
+    "kind": "Task",
+    "latestVersion": 4,
+    "name": "aws-cli",
+    "rating": 5,
+    "readme": "",
+    "resourceKey": "tekton/Task/aws-cli",
+    "tags": Array [
+      2,
+    ],
+    "versions": Array [
+      4,
+    ],
+    "yaml": "",
+  },
+  "tekton/Task/buildah": Object {
+    "catalog": 1,
+    "displayName": "",
+    "displayVersion": 105,
+    "id": 13,
+    "kind": "Task",
+    "latestVersion": 105,
+    "name": "buildah",
+    "rating": 4,
+    "readme": "",
+    "resourceKey": "tekton/Task/buildah",
+    "tags": Array [
+      8,
+    ],
+    "versions": Array [
+      105,
+    ],
+    "yaml": "",
+  },
+  "tekton/Task/golang-build": Object {
+    "catalog": 1,
+    "displayName": "golang build",
+    "displayVersion": 47,
+    "id": 44,
+    "kind": "Task",
+    "latestVersion": 47,
+    "name": "golang-build",
+    "rating": 5,
+    "readme": "",
+    "resourceKey": "tekton/Task/golang-build",
+    "tags": Array [
+      1,
+    ],
+    "versions": Array [
+      47,
+    ],
+    "yaml": "",
+  },
+  "tekton/Task/jenkins": Object {
     "catalog": 1,
     "displayName": "jenkins operation",
     "displayVersion": 104,
@@ -532,6 +716,7 @@ Object {
     "name": "jenkins",
     "rating": 5,
     "readme": "",
+    "resourceKey": "tekton/Task/jenkins",
     "tags": Array [
       57,
       56,
@@ -541,7 +726,7 @@ Object {
     ],
     "yaml": "",
   },
-  "jib-maven": Object {
+  "tekton/Task/jib-maven": Object {
     "catalog": 1,
     "displayName": "jib maven",
     "displayVersion": 57,
@@ -551,6 +736,7 @@ Object {
     "name": "jib-maven",
     "rating": 5,
     "readme": "",
+    "resourceKey": "tekton/Task/jib-maven",
     "tags": Array [
       8,
     ],
@@ -564,79 +750,7 @@ Object {
 
 exports[`Store functions update versions list for buildah resource 1`] = `
 Object {
-  "ansible-runner": Object {
-    "catalog": 1,
-    "displayName": "Ansible Runner",
-    "displayVersion": 1,
-    "id": 1,
-    "kind": "Task",
-    "latestVersion": 1,
-    "name": "ansible-runner",
-    "rating": 4.5,
-    "readme": "",
-    "tags": Array [
-      2,
-    ],
-    "versions": Array [
-      1,
-    ],
-    "yaml": "",
-  },
-  "aws-cli": Object {
-    "catalog": 1,
-    "displayName": "aws cli",
-    "displayVersion": 4,
-    "id": 4,
-    "kind": "Task",
-    "latestVersion": 4,
-    "name": "aws-cli",
-    "rating": 5,
-    "readme": "",
-    "tags": Array [
-      2,
-    ],
-    "versions": Array [
-      4,
-    ],
-    "yaml": "",
-  },
-  "buildah": Object {
-    "catalog": 1,
-    "displayName": "",
-    "displayVersion": 105,
-    "id": 13,
-    "kind": "Task",
-    "latestVersion": 105,
-    "name": "buildah",
-    "rating": 4,
-    "readme": "",
-    "tags": Array [
-      8,
-    ],
-    "versions": Array [
-      105,
-    ],
-    "yaml": "",
-  },
-  "golang-build": Object {
-    "catalog": 1,
-    "displayName": "golang build",
-    "displayVersion": 47,
-    "id": 44,
-    "kind": "Task",
-    "latestVersion": 47,
-    "name": "golang-build",
-    "rating": 5,
-    "readme": "",
-    "tags": Array [
-      1,
-    ],
-    "versions": Array [
-      47,
-    ],
-    "yaml": "",
-  },
-  "hub": Object {
+  "tekton-hub/Pipeline/hub": Object {
     "catalog": 2,
     "displayName": "Hub Pipeline",
     "displayVersion": 1,
@@ -646,6 +760,7 @@ Object {
     "name": "hub",
     "rating": 4.5,
     "readme": "",
+    "resourceKey": "tekton-hub/Pipeline/hub",
     "tags": Array [
       10,
     ],
@@ -654,7 +769,83 @@ Object {
     ],
     "yaml": "",
   },
-  "jenkins": Object {
+  "tekton/Task/ansible-runner": Object {
+    "catalog": 1,
+    "displayName": "Ansible Runner",
+    "displayVersion": 1,
+    "id": 1,
+    "kind": "Task",
+    "latestVersion": 1,
+    "name": "ansible-runner",
+    "rating": 4.5,
+    "readme": "",
+    "resourceKey": "tekton/Task/ansible-runner",
+    "tags": Array [
+      2,
+    ],
+    "versions": Array [
+      1,
+    ],
+    "yaml": "",
+  },
+  "tekton/Task/aws-cli": Object {
+    "catalog": 1,
+    "displayName": "aws cli",
+    "displayVersion": 4,
+    "id": 4,
+    "kind": "Task",
+    "latestVersion": 4,
+    "name": "aws-cli",
+    "rating": 5,
+    "readme": "",
+    "resourceKey": "tekton/Task/aws-cli",
+    "tags": Array [
+      2,
+    ],
+    "versions": Array [
+      4,
+    ],
+    "yaml": "",
+  },
+  "tekton/Task/buildah": Object {
+    "catalog": 1,
+    "displayName": "",
+    "displayVersion": 105,
+    "id": 13,
+    "kind": "Task",
+    "latestVersion": 105,
+    "name": "buildah",
+    "rating": 4,
+    "readme": "",
+    "resourceKey": "tekton/Task/buildah",
+    "tags": Array [
+      8,
+    ],
+    "versions": Array [
+      105,
+    ],
+    "yaml": "",
+  },
+  "tekton/Task/golang-build": Object {
+    "catalog": 1,
+    "displayName": "golang build",
+    "displayVersion": 47,
+    "id": 44,
+    "kind": "Task",
+    "latestVersion": 47,
+    "name": "golang-build",
+    "rating": 5,
+    "readme": "",
+    "resourceKey": "tekton/Task/golang-build",
+    "tags": Array [
+      1,
+    ],
+    "versions": Array [
+      47,
+    ],
+    "yaml": "",
+  },
+  "tekton/Task/jenkins": Object {
     "catalog": 1,
     "displayName": "jenkins operation",
     "displayVersion": 104,
@@ -664,6 +855,7 @@ Object {
     "name": "jenkins",
     "rating": 5,
     "readme": "",
+    "resourceKey": "tekton/Task/jenkins",
     "tags": Array [
       57,
       56,
@@ -673,7 +865,7 @@ Object {
     ],
     "yaml": "",
   },
-  "jib-maven": Object {
+  "tekton/Task/jib-maven": Object {
     "catalog": 1,
     "displayName": "jib maven",
     "displayVersion": 57,
@@ -683,6 +875,7 @@ Object {
     "name": "jib-maven",
     "rating": 5,
     "readme": "",
+    "resourceKey": "tekton/Task/jib-maven",
     "tags": Array [
       8,
     ],

--- a/ui/src/store/resource.test.ts
+++ b/ui/src/store/resource.test.ts
@@ -13,6 +13,7 @@ describe('Store Object', () => {
     const store = Resource.create({
       id: 5,
       name: 'buildah',
+      resourceKey: 'tekton/Task/buildah',
       catalog: '1',
       kind: 'Task',
       latestVersion: 1,
@@ -198,6 +199,7 @@ describe('Store functions', () => {
         const item = Resource.create({
           id: 44,
           name: 'golang-build',
+          resourceKey: 'tekton/Task/golang-build',
           catalog: 1,
           kind: 'Task',
           latestVersion: 47,
@@ -277,7 +279,7 @@ describe('Store functions', () => {
         expect(store.isLoading).toBe(false);
         expect(store.resources.size).toBe(7);
 
-        const resource = store.resources.get('aws-cli');
+        const resource = store.resources.get('tekton/Task/aws-cli');
         assert(resource);
 
         expect(resource.resourceName).toBe('aws cli');
@@ -329,7 +331,7 @@ describe('Store functions', () => {
         expect(store.isLoading).toBe(false);
         expect(store.resources.size).toBe(7);
 
-        const resource = store.resources.get('aws-cli');
+        const resource = store.resources.get('tekton/Task/aws-cli');
         assert(resource);
 
         expect(resource.webURL).toBe(
@@ -355,7 +357,7 @@ describe('Store functions', () => {
         expect(store.isLoading).toBe(false);
         expect(store.resources.size).toBe(7);
 
-        const resource = store.resources.get('aws-cli');
+        const resource = store.resources.get('tekton/Task/aws-cli');
         assert(resource);
 
         expect(resource.summary).toBe(
@@ -381,7 +383,7 @@ describe('Store functions', () => {
         expect(store.isLoading).toBe(false);
         expect(store.resources.size).toBe(7);
 
-        const resource = store.resources.get('buildah');
+        const resource = store.resources.get('tekton/Task/buildah');
         assert(resource);
 
         expect(resource.detailDescription).toBe(
@@ -407,7 +409,7 @@ describe('Store functions', () => {
         expect(store.isLoading).toBe(false);
         expect(store.resources.size).toBe(7);
 
-        const resource = store.resources.get('aws-cli');
+        const resource = store.resources.get('tekton/Task/aws-cli');
         assert(resource);
 
         expect(resource.installCommand).toBe(
@@ -434,11 +436,11 @@ describe('Store functions', () => {
       () => {
         expect(store.resources.size).toBe(7);
         expect(getSnapshot(store.resources)).toMatchSnapshot();
-        store.versionInfo('buildah');
+        store.versionInfo('tekton/Task/buildah');
         when(
           () => !store.isLoading,
           () => {
-            const resource = store.resources.get('buildah');
+            const resource = store.resources.get('tekton/Task/buildah');
             assert(resource);
             expect(resource.versions.length).toBe(2);
             done();
@@ -464,11 +466,11 @@ describe('Store functions', () => {
       () => {
         expect(store.resources.size).toBe(7);
         expect(getSnapshot(store.resources)).toMatchSnapshot();
-        store.versionInfo('buildah');
+        store.versionInfo('tekton/Task/buildah');
         when(
           () => !store.isLoading,
           () => {
-            const resource = store.resources.get('buildah');
+            const resource = store.resources.get('tekton/Task/buildah');
             assert(resource);
             expect(resource.versions.length).toBe(2);
             store.versionUpdate(13);
@@ -502,14 +504,14 @@ describe('Store functions', () => {
       () => {
         expect(store.resources.size).toBe(7);
         expect(getSnapshot(store.resources)).toMatchSnapshot();
-        store.versionInfo('buildah');
+        store.versionInfo('tekton/Task/buildah');
         when(
           () => !store.isLoading,
           () => {
-            const resource = store.resources.get('buildah');
+            const resource = store.resources.get('tekton/Task/buildah');
             assert(resource);
             expect(resource.versions.length).toBe(2);
-            store.setDisplayVersion('buildah', '13');
+            store.setDisplayVersion('tekton/Task/buildah', '13');
             when(
               () => !store.isLoading,
               () => {
@@ -543,7 +545,7 @@ describe('Store functions', () => {
         when(
           () => !store.isLoading,
           () => {
-            const resource = store.resources.get('buildah');
+            const resource = store.resources.get('tekton/Task/buildah');
             assert(resource);
 
             expect(typeof resource.readme).toBe('string');
@@ -573,7 +575,7 @@ describe('Store functions', () => {
         when(
           () => !store.isLoading,
           () => {
-            const resource = store.resources.get('buildah');
+            const resource = store.resources.get('tekton/Task/buildah');
             assert(resource);
 
             expect(typeof resource.readme).toBe('string');
@@ -602,6 +604,45 @@ describe('Store functions', () => {
 
         store.clearAllFilters();
         expect(store.filteredResources.length).toBe(7);
+
+        done();
+      }
+    );
+  });
+
+  it('makes sure to add resources with same name but from different catalog', (done) => {
+    const store = ResourceStore.create(
+      {},
+      {
+        api,
+        categories: CategoryStore.create({}, { api })
+      }
+    );
+
+    expect(store.isLoading).toBe(true);
+
+    when(
+      () => !store.isLoading,
+      () => {
+        const item = Resource.create({
+          id: 44,
+          name: 'golang-build',
+          resourceKey: 'tekton-hub/Task/golang-build',
+          catalog: 2,
+          kind: 'Task',
+          latestVersion: 47,
+          displayVersion: 47,
+          tags: [1],
+          rating: 5,
+          versions: [47],
+          displayName: 'golang build'
+        });
+
+        expect(store.resources.size).toBe(7);
+        store.add(item);
+        expect(store.resources.size).toBe(8);
+
+        expect(getSnapshot(store.resources)).toMatchSnapshot();
 
         done();
       }


### PR DESCRIPTION
  - Initially `name` was used as an identifier to get the resource details
    which used to avoid adding resources with same name from different catalog.

 -  This patch add `uniqueKey` as an identifier which has value as
    `catalog-name/kind-name/resource-name` which adds support for
     muli-catalog

Signed-off-by: Puneet Punamiya <ppunamiy@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

