### PR TITLE
UI: Add `tkn cli` command to install task from UI

### DIFF
--- a/ui/src/containers/BasicDetails/index.tsx
+++ b/ui/src/containers/BasicDetails/index.tsx
@@ -163,10 +163,18 @@ const BasicDetails: React.FC = () => {
             <hr />
             <div>
               <TextContent>
-                <Text component={TextVariants.h2}>Install on Kubernetes</Text>
+                <Text component={TextVariants.h2}>Install using kubectl</Text>
                 <Text> {resource.kind.name} </Text>
                 <ClipboardCopy isReadOnly variant={ClipboardCopyVariant.expansion}>
                   {resource.installCommand}
+                </ClipboardCopy>
+              </TextContent>
+              <br />
+              <TextContent>
+                <Text component={TextVariants.h2}>Install using tkn</Text>
+                <Text> {resource.kind.name} </Text>
+                <ClipboardCopy isReadOnly variant={ClipboardCopyVariant.expansion}>
+                  {resource.tknInstallCommand}
                 </ClipboardCopy>
               </TextContent>
             </div>

--- a/ui/src/store/resource.test.ts
+++ b/ui/src/store/resource.test.ts
@@ -648,4 +648,35 @@ describe('Store functions', () => {
       }
     );
   });
+
+  it('it should return tkn hub install command', (done) => {
+    const store = ResourceStore.create(
+      {},
+      {
+        api,
+        categories: CategoryStore.create({}, { api })
+      }
+    );
+    expect(store.isLoading).toBe(true);
+    when(
+      () => !store.isLoading,
+      () => {
+        expect(store.isLoading).toBe(false);
+        expect(store.resources.size).toBe(7);
+
+        const tektonResource = store.resources.get('tekton/Task/aws-cli');
+        assert(tektonResource);
+
+        expect(tektonResource.tknInstallCommand).toBe('tkn hub install task aws-cli');
+
+        const hubResource = store.resources.get('tekton-hub/Pipeline/hub');
+
+        assert(hubResource);
+        expect(hubResource.tknInstallCommand).toBe(
+          'tkn hub install pipeline hub --from tekton-hub'
+        );
+        done();
+      }
+    );
+  });
 });

--- a/ui/src/store/resource.ts
+++ b/ui/src/store/resource.ts
@@ -77,6 +77,19 @@ export const Resource = types
     },
     get installCommand() {
       return `kubectl apply -f ${self.displayVersion.rawURL}`;
+    },
+    get tknInstallCommand() {
+      const versionFlag =
+        self.latestVersion.version !== self.displayVersion.version
+          ? ` --version ${self.displayVersion.version}`
+          : ``;
+      const catalogFlag =
+        self.catalog.name.toLowerCase() !== 'tekton'
+          ? ` --from ${self.catalog.name.toLowerCase()}`
+          : ``;
+      return `tkn hub install ${self.kind.name.toLowerCase()} ${
+        self.name
+      }${versionFlag}${catalogFlag}`;
     }
   }));
 


### PR DESCRIPTION
# Changes

As of now we display only `kubectl` command when we click on the install
button present in the card of a resource on resource details page.

This PR adds the `tkn hub install resource` command along with `kubectl`
command so that if someone want to use tkn cli then they can install
task directly from there.

![image](https://user-images.githubusercontent.com/26500025/112451779-e1940480-8d7b-11eb-8ab1-f93307f39fe2.png)


Closes #196 

Signed-off-by: vinamra28 <vinjain@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._

