### PR TITLE
Adds catalog name in hub cli search command

### DIFF
--- a/api/pkg/cli/cmd/search/search.go
+++ b/api/pkg/cli/cmd/search/search.go
@@ -31,18 +31,19 @@ import (
 const resTemplate = `{{- $rl := len .Resources }}{{ if eq $rl 0 -}}
 No Resources found
 {{ else -}}
-NAME	KIND	DESCRIPTION	TAGS
+NAME	KIND	CATALOG	DESCRIPTION	TAGS
 {{ range $_, $r := .Resources -}}
-{{ formatName $r.Name $r.LatestVersion.Version }}	{{ $r.Kind }}	{{ formatDesc $r.LatestVersion.Description 40 }}	{{ formatTags $r.Tags }}	
+{{ formatName $r.Name $r.LatestVersion.Version }}	{{ $r.Kind }}	{{ formatCatalogName $r.Catalog.Name }}	{{ formatDesc $r.LatestVersion.Description 40 }}	{{ formatTags $r.Tags }}
 {{ end }}
 {{- end -}}
 `
 
 var (
 	funcMap = template.FuncMap{
-		"formatName": formatter.FormatName,
-		"formatDesc": formatter.FormatDesc,
-		"formatTags": formatter.FormatTags,
+		"formatName":        formatter.FormatName,
+		"formatCatalogName": formatter.FormatCatalogName,
+		"formatDesc":        formatter.FormatDesc,
+		"formatTags":        formatter.FormatTags,
 	}
 	tmpl = template.Must(template.New("List Resources").Funcs(funcMap).Parse(resTemplate))
 )

--- a/api/pkg/cli/cmd/search/search_test.go
+++ b/api/pkg/cli/cmd/search/search_test.go
@@ -33,6 +33,7 @@ var res1 = &res.ResourceData{
 	Kind: "Task",
 	Catalog: &res.Catalog{
 		ID:   1,
+		Name: "tekton",
 		Type: "community",
 	},
 	Rating: 4.8,
@@ -47,8 +48,8 @@ var res1 = &res.ResourceData{
 		UpdatedAt:           "2020-01-01 12:00:00 +0000 UTC",
 	},
 	Tags: []*res.Tag{
-		&res.Tag{ID: 3, Name: "tag3"},
-		&res.Tag{ID: 1, Name: "tag1"},
+		{ID: 3, Name: "tag3"},
+		{ID: 1, Name: "tag1"},
 	},
 }
 
@@ -58,6 +59,7 @@ var res2 = &res.ResourceData{
 	Kind: "Pipeline",
 	Catalog: &res.Catalog{
 		ID:   1,
+		Name: "foo",
 		Type: "community",
 	},
 	Rating: 4,

--- a/api/pkg/cli/cmd/search/testdata/TestSearch_JSONFormat.golden
+++ b/api/pkg/cli/cmd/search/testdata/TestSearch_JSONFormat.golden
@@ -5,7 +5,7 @@
 			"Name": "foo-bar",
 			"Catalog": {
 				"ID": 1,
-				"Name": "",
+				"Name": "foo",
 				"Type": "community"
 			},
 			"Kind": "Pipeline",

--- a/api/pkg/cli/cmd/search/testdata/TestSearch_TableFormat.golden
+++ b/api/pkg/cli/cmd/search/testdata/TestSearch_TableFormat.golden
@@ -1,3 +1,3 @@
-NAME            KIND       DESCRIPTION                                  TAGS
-foo (0.1)       Task       Description for task abc version 0.1         tag3, tag1   
-foo-bar (0.2)   Pipeline   Description for pipeline foo-bar versio...   ---          
+NAME            KIND       CATALOG   DESCRIPTION                                  TAGS
+foo (0.1)       Task       Tekton    Description for task abc version 0.1         tag3, tag1
+foo-bar (0.2)   Pipeline   Foo       Description for pipeline foo-bar versio...   ---

--- a/api/pkg/cli/formatter/field.go
+++ b/api/pkg/cli/formatter/field.go
@@ -40,6 +40,11 @@ func FormatName(name, latestVersion string) string {
 	return fmt.Sprintf("%s (%s)", name, latestVersion)
 }
 
+// FormatCatalogName returns name of catalog from which the resource is
+func FormatCatalogName(catalogName string) string {
+	return fmt.Sprintf("%s", strings.Title(catalogName))
+}
+
 // FormatDesc returns first 40 char of resource description
 func FormatDesc(desc string, num int) string {
 

--- a/api/pkg/cli/formatter/field_test.go
+++ b/api/pkg/cli/formatter/field_test.go
@@ -26,6 +26,11 @@ func TestFormatName(t *testing.T) {
 	assert.Equal(t, name, "abc (0.1)")
 }
 
+func TestFormatCatalogName(t *testing.T) {
+	catalog := FormatCatalogName("foo")
+	assert.Equal(t, catalog, "Foo")
+}
+
 func TestFormatDesc(t *testing.T) {
 
 	// Description greater than 40 char


### PR DESCRIPTION
   - This patch displays the name of the catalog from which
     the resource is on searching the resource using
     `tkn hub search <resourceName>`

```bash=
╰─ tkn hub search golang 
NAME                  KIND   CATALOG   DESCRIPTION                                  TAGS
golang-build (0.1)    Task   Tekton    This Task is Golang task to build Go pr...   build-tool
golangci-lint (0.1)   Task   Tekton    This Task is Golang task to validate Go...   lint
```


    
Signed-off-by: Puneet Punamiya <ppunamiy@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._

