### PR TITLE
Minor bug fix in Hub CLI info command

### DIFF
--- a/api/pkg/cli/formatter/field.go
+++ b/api/pkg/cli/formatter/field.go
@@ -108,6 +108,7 @@ func breakString(desc string, width, titleLength int) string {
 	for i := firstLineEnd; i < descLength; i = i + spaceIndex {
 		if descLength < i+width {
 			sb.WriteString(desc[i:])
+			break
 		} else {
 			spaceIndex = findSpaceIndexFromLast(desc[i : i+width])
 			sb.WriteString(desc[i:i+spaceIndex] + "\n")

--- a/api/pkg/cli/formatter/field_test.go
+++ b/api/pkg/cli/formatter/field_test.go
@@ -68,6 +68,17 @@ func TestFormatTags(t *testing.T) {
 	assert.Equal(t, "---", tags)
 }
 
+func TestWrapText(t *testing.T) {
+
+	// Description of resource with just summa
+	desc := WrapText("The Buildpacks task builds source into a container image and pushes it to a registry, using Cloud Native Buildpacks.", 80, 16)
+	assert.Equal(t, "The Buildpacks task builds source into a container image and"+"\n"+" pushes it to a registry, using Cloud Native Buildpacks.", desc)
+
+	// Description of resource with summary and description
+	desc = WrapText("Buildah task builds source into a container image and then pushes it to a container registry."+"\n"+"Buildah Task builds source into a container image using Project Atomic's Buildah build tool.It uses Buildah's support for building from Dockerfiles, using its buildah bud command.This command executes the directives in the Dockerfile to assemble a container image, then pushes that image to a container registry.", 80, 16)
+	assert.Equal(t, "Buildah task builds source into a container image and then"+"\n"+" pushes it to a container registry. Buildah Task builds source into a container"+"\n"+" image using Project Atomic's Buildah build tool.It uses Buildah's support for"+"\n"+" building from Dockerfiles, using its buildah bud command.This command executes"+"\n"+" the directives in the Dockerfile to assemble a container image, then pushes"+"\n"+" that image to a container registry.", desc)
+}
+
 func TestFormatVersion(t *testing.T) {
 	got := FormatVersion("0.1", false)
 	assert.Equal(t, "0.1", got)


### PR DESCRIPTION
   - Fixes the logic by adding a break statement
     in formatting the description of resource in
     Hub CLI info command

   - Adds tests for wrapText function which formats
     the description of resource

Signed-off-by: Puneet Punamiya <ppunamiy@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._

