### PR TITLE
CLI: Respect pipelines version in CLI subcommands

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/go-gormigrate/gormigrate/v2 v2.0.0
 	github.com/go-testfixtures/testfixtures/v3 v3.2.0
 	github.com/google/go-github v17.0.0+incompatible
-	github.com/hashicorp/go-version v1.2.0
 	github.com/ikawaha/goahttpcheck v1.3.1
 	github.com/joho/godotenv v1.3.0
 	github.com/mitchellh/go-homedir v1.1.0

--- a/api/go.sum
+++ b/api/go.sum
@@ -531,7 +531,6 @@ github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerX
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
-github.com/hashicorp/go-version v1.2.0 h1:3vNe/fWF5CBgRIguda1meWhsZHy3m8gCJ5wx+dIzX/E=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=

--- a/api/pkg/cli/cmd/downgrade/downgrade.go
+++ b/api/pkg/cli/cmd/downgrade/downgrade.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/go-version"
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/hub/api/pkg/cli/app"
 	"github.com/tektoncd/hub/api/pkg/cli/flag"
@@ -122,8 +121,8 @@ func (opts *options) run() error {
 		}
 	}
 
-	installer := installer.New(opts.cs)
-	opts.resource, err = installer.LookupInstalled(opts.name(), opts.kind, opts.cs.Namespace())
+	resInstaller := installer.New(opts.cs)
+	opts.resource, err = resInstaller.LookupInstalled(opts.name(), opts.kind, opts.cs.Namespace())
 	if err != nil {
 		if err = opts.lookupError(err); err != nil {
 			return err
@@ -156,12 +155,21 @@ func (opts *options) run() error {
 		return err
 	}
 
-	opts.resource, err = installer.Downgrade(manifest, catalog, opts.cs.Namespace())
-	if err != nil {
-		return opts.errors(err)
+	out := opts.cli.Stream().Out
+
+	var errors []error
+	opts.resource, errors = resInstaller.Downgrade(manifest, catalog, opts.cs.Namespace())
+	if len(errors) != 0 {
+
+		resourcePipelineMinVersion := opts.resource.GetAnnotations()[installer.ResourceMinVersion]
+
+		if errors[0] == installer.ErrWarnVersionNotFound && len(errors) == 1 {
+			_ = printer.New(out).String("WARN: tekton pipelines version unknown, this resource is compatible with pipelines min version v" + resourcePipelineMinVersion)
+		} else {
+			return opts.errors(resourcePipelineMinVersion, resInstaller.GetPipelineVersion(), errors)
+		}
 	}
 
-	out := opts.cli.Stream().Out
 	return printer.New(out).String(msg(opts.resource))
 }
 
@@ -173,9 +181,7 @@ func msg(res *unstructured.Unstructured) string {
 
 func (opts *options) findLowerVersion(current string) (string, error) {
 	if opts.version != "" {
-		currentVer, _ := version.NewVersion(current)
-		newVer, _ := version.NewVersion(opts.version)
-		if currentVer.LessThan(newVer) {
+		if current < opts.version {
 			return "", fmt.Errorf("cannot downgrade %s %s to v%s. existing resource seems to be of lower version(v%s). Use upgrade command",
 				opts.kind, opts.name(), opts.version, current)
 		}
@@ -248,23 +254,31 @@ func (opts *options) lookupError(err error) error {
 	}
 }
 
-func (opts *options) errors(err error) error {
+func (opts *options) errors(resourcePipelineMinVersion, pipelinesVersion string, errors []error) error {
 
-	if err == installer.ErrNotFound {
-		return fmt.Errorf("%s %s doesn't exists in %s namespace. Use install command to install the resource",
-			strings.Title(opts.kind), opts.name(), opts.cs.Namespace())
+	for _, err := range errors {
+
+		if err == installer.ErrNotFound {
+			return fmt.Errorf("%s %s doesn't exists in %s namespace. Use install command to install the resource",
+				strings.Title(opts.kind), opts.name(), opts.cs.Namespace())
+		}
+
+		if err == installer.ErrSameVersion {
+			return fmt.Errorf("cannot downgrade %s %s to v%s. existing resource seems to be of same version. Use reinstall command to overwrite existing %s",
+				strings.ToLower(opts.resource.GetKind()), opts.resource.GetName(), opts.version, opts.kind)
+		}
+
+		if err == installer.ErrVersionIncompatible {
+			return fmt.Errorf("cannot downgrade %s %s to v%s as it requires Pipelines min version v%s but found %s", strings.Title(opts.kind), opts.name(), opts.version, resourcePipelineMinVersion, pipelinesVersion)
+		}
+
+		if err == installer.ErrHigherVersion {
+			existingVersion := opts.resource.GetLabels()[versionLabel]
+			return fmt.Errorf("cannot downgrade %s %s to v%s. existing resource seems to be of lower version(v%s). Use upgrade command",
+				strings.ToLower(opts.resource.GetKind()), opts.resource.GetName(), opts.version, existingVersion)
+		}
+
 	}
 
-	if err == installer.ErrSameVersion {
-		return fmt.Errorf("cannot downgrade %s %s to v%s. existing resource seems to be of same version. Use reinstall command to overwrite existing %s",
-			strings.ToLower(opts.resource.GetKind()), opts.resource.GetName(), opts.version, opts.kind)
-	}
-
-	if err == installer.ErrHigherVersion {
-		existingVersion := opts.resource.GetLabels()[versionLabel]
-		return fmt.Errorf("cannot downgrade %s %s to v%s. existing resource seems to be of lower version(v%s). Use upgrade command",
-			strings.ToLower(opts.resource.GetKind()), opts.resource.GetName(), opts.version, existingVersion)
-	}
-
-	return err
+	return errors[0]
 }

--- a/api/pkg/cli/cmd/upgrade/upgrade.go
+++ b/api/pkg/cli/cmd/upgrade/upgrade.go
@@ -120,8 +120,8 @@ func (opts *options) run() error {
 		}
 	}
 
-	installer := installer.New(opts.cs)
-	opts.resource, err = installer.LookupInstalled(opts.name(), opts.kind, opts.cs.Namespace())
+	resInstaller := installer.New(opts.cs)
+	opts.resource, err = resInstaller.LookupInstalled(opts.name(), opts.kind, opts.cs.Namespace())
 	if err != nil {
 		if err = opts.lookupError(err); err != nil {
 			return err
@@ -143,12 +143,25 @@ func (opts *options) run() error {
 		return err
 	}
 
-	opts.resource, err = installer.Upgrade(manifest, catalog, opts.cs.Namespace())
-	if err != nil {
-		return opts.errors(err)
+	out := opts.cli.Stream().Out
+
+	var errors []error
+	opts.resource, errors = resInstaller.Upgrade(manifest, catalog, opts.cs.Namespace())
+	if len(errors) != 0 {
+
+		resourcePipelineMinVersion, vErr := opts.hubRes.MinPipelinesVersion()
+		if vErr != nil {
+			fmt.Println("yha aya")
+			return vErr
+		}
+
+		if errors[0] == installer.ErrWarnVersionNotFound && len(errors) == 1 {
+			_ = printer.New(out).String("WARN: tekton pipelines version unknown, this resource is compatible with pipelines min version v" + resourcePipelineMinVersion)
+		} else {
+			return opts.errors(resourcePipelineMinVersion, resInstaller.GetPipelineVersion(), errors)
+		}
 	}
 
-	out := opts.cli.Stream().Out
 	return printer.New(out).String(msg(opts.resource))
 }
 
@@ -207,37 +220,39 @@ func (opts *options) lookupError(err error) error {
 	}
 }
 
-func (opts *options) errors(err error) error {
+func (opts *options) errors(resourcePipelineMinVersion, pipelinesVersion string, errors []error) error {
 
 	newVersion, hubErr := opts.hubRes.ResourceVersion()
 	if hubErr != nil {
 		return hubErr
 	}
 
-	if err == installer.ErrNotFound {
-		return fmt.Errorf("%s %s doesn't exists in %s namespace. Use install command to install the %s",
-			strings.Title(opts.kind), opts.name(), opts.cs.Namespace(), opts.kind)
-	}
-
-	if err == installer.ErrSameVersion {
-		return fmt.Errorf("cannot upgrade %s %s to v%s. existing resource seems to be of same version. Use reinstall command to overwrite existing %s",
-			strings.ToLower(opts.resource.GetKind()), opts.resource.GetName(), newVersion, opts.kind)
-	}
-
-	if err == installer.ErrLowerVersion {
-		existingVersion := opts.resource.GetLabels()[versionLabel]
-		return fmt.Errorf("cannot upgrade %s %s to v%s. existing resource seems to be of higher version(v%s). Use downgrade command",
-			strings.ToLower(opts.resource.GetKind()), opts.resource.GetName(), newVersion, existingVersion)
-	}
-
-	if strings.Contains(err.Error(), "mutation failed: cannot decode incoming new object") {
-		version, vErr := opts.hubRes.MinPipelinesVersion()
-		if vErr != nil {
-			return vErr
+	for _, err := range errors {
+		if err == installer.ErrNotFound {
+			return fmt.Errorf("%s %s doesn't exists in %s namespace. Use install command to install the %s",
+				strings.Title(opts.kind), opts.name(), opts.cs.Namespace(), opts.kind)
 		}
-		return fmt.Errorf("%v \nMake sure the pipeline version you are running is not lesser than %s and %s have correct spec fields",
-			err, version, opts.kind)
+
+		if err == installer.ErrSameVersion {
+			return fmt.Errorf("cannot upgrade %s %s to v%s. existing resource seems to be of same version. Use reinstall command to overwrite existing %s",
+				strings.ToLower(opts.resource.GetKind()), opts.resource.GetName(), newVersion, opts.kind)
+		}
+
+		if err == installer.ErrLowerVersion {
+			existingVersion := opts.resource.GetLabels()[versionLabel]
+			return fmt.Errorf("cannot upgrade %s %s to v%s. existing resource seems to be of higher version(v%s). Use downgrade command",
+				strings.ToLower(opts.resource.GetKind()), opts.resource.GetName(), newVersion, existingVersion)
+		}
+
+		if err == installer.ErrVersionIncompatible {
+			return fmt.Errorf("cannot upgrade %s %s(%s) as it requires Tekton Pipelines min version v%s but found %s", strings.Title(opts.kind), opts.name(), newVersion, resourcePipelineMinVersion, pipelinesVersion)
+		}
+
+		if strings.Contains(err.Error(), "mutation failed: cannot decode incoming new object") {
+			return fmt.Errorf("%v \nMake sure the pipeline version you are running is not lesser than %s and %s have correct spec fields",
+				err, resourcePipelineMinVersion, opts.kind)
+		}
 	}
 
-	return err
+	return errors[0]
 }


### PR DESCRIPTION
# Changes

As of now when we do `tkn hub <subcommand> task taskname` without taking care
of the version of Tekton Pipelines installed on the cluster and due to
this it might break the TaskRun or PipelineRun created by the user if
the required Pipelines version is greater than that installed on the
cluster. Eg buildah 0.2 requires pipelines minVersion to be 0.17.0 and
we have 0.16.3 installed on our cluster so when running this task it
will break.

With this patch we will respect the min version required to run the task
which we get from the annotation present in the task as
pipelines.minVersion and the installed pipelines version.
- If the installed pipelines version is greater than pipelines.minVersion value
then the task will be upgraded/downgraded/reinstalled directly.
- If the installed pipelines version is lesser than pipelines.minVersion
value it will error out.
- If the pipelines controller is installed on another namespace other
than `tekton-pipelines` and `openshift-pipelines` then it will give the
warning and upgrade/downgrade/reinstall the task.

Signed-off-by: vinamra28 <vinjain@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._

