### PR TITLE
UI: Fixes to rate a resource

### DIFF
--- a/ui/src/containers/Rating/Rating.test.tsx
+++ b/ui/src/containers/Rating/Rating.test.tsx
@@ -19,7 +19,9 @@ jest.mock('react-router-dom', () => {
     },
     useParams: () => {
       return {
-        name: 'buildah'
+        name: 'buildah',
+        catalog: 'tekton',
+        kind: 'Task'
       };
     }
   };

--- a/ui/src/containers/Rating/index.tsx
+++ b/ui/src/containers/Rating/index.tsx
@@ -8,10 +8,12 @@ import { assert } from '../../store/utils';
 import { Icons } from '../../common/icons';
 import Icon from '../../components/Icon';
 import AlertDisplay from '../../components/AlertDisplay';
+import { titleCase } from '../../common/titlecase';
 import './Rating.css';
 
 const Rating: React.FC = observer(() => {
-  const { name } = useParams();
+  const { name, kind, catalog } = useParams();
+  const resourceKey = `${catalog}/${titleCase(kind)}/${name}`;
 
   const [star, setStar] = useState([false, false, false, false, false]);
   const [ratingError, setRatingError] = useState('');
@@ -74,7 +76,7 @@ const Rating: React.FC = observer(() => {
       history.push('/login');
     } else {
       if (rating) {
-        const resource = resources.resources.get(name);
+        const resource = resources.resources.get(resourceKey);
         assert(resource);
         user.setRating(resource.id, Number(rating));
         if (user.ratingErr === '') {


### PR DESCRIPTION
Previously it was using name to access a resource from store but needs
a key(containing resource's name,kind and catalag name) to access it

Sigend-off-by: Shiv Verma <shverma@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->



<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._

