### PR TITLE
CLI: Improves error message for search command

### DIFF
--- a/api/pkg/cli/cmd/search/search.go
+++ b/api/pkg/cli/cmd/search/search.go
@@ -138,7 +138,7 @@ func (opts *options) run() error {
 func (opts *options) validate() error {
 
 	if flag.AllEmpty(opts.args, opts.kinds, opts.tags) {
-		return fmt.Errorf("please specify a name, tag or a kind to search")
+		return fmt.Errorf("please specify a resource name, --tags or --kinds flag to search")
 	}
 
 	if err := flag.InList("match", opts.match, []string{"contains", "exact"}); err != nil {

--- a/api/pkg/cli/cmd/search/search_test.go
+++ b/api/pkg/cli/cmd/search/search_test.go
@@ -102,7 +102,7 @@ func TestValidate_ErrorCases(t *testing.T) {
 	opt := options{}
 	err := opt.validate()
 	assert.Error(t, err)
-	assert.EqualError(t, err, "please specify a name, tag or a kind to search")
+	assert.EqualError(t, err, "please specify a resource name, --tags or --kinds flag to search")
 
 	opt = options{
 		kinds:  []string{"abc"},


### PR DESCRIPTION
This improves the error messsage to use resource name or any of the
kind or tags flag to search the resource.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._

