### PR TITLE
UI: Scroll to top of home page when users click on the Hub logo

### DIFF
--- a/ui/src/common/scrollToTop.test.ts
+++ b/ui/src/common/scrollToTop.test.ts
@@ -1,0 +1,10 @@
+import { scrollToTop } from './scrollToTop';
+
+describe('Test scrollToTop function', () => {
+  it('should move the page to top', () => {
+    scrollToTop();
+
+    expect(window.screenX).toBe(0);
+    expect(window.screenY).toBe(0);
+  });
+});

--- a/ui/src/common/scrollToTop.ts
+++ b/ui/src/common/scrollToTop.ts
@@ -1,0 +1,8 @@
+import { assert } from '../store/utils';
+
+// This function moves the page to top
+export const scrollToTop = () => {
+  const scroller = document.querySelector('main');
+  assert(scroller);
+  if (scroller) scroller.scrollTo(0, 0);
+};

--- a/ui/src/containers/App/__snapshots__/App.test.tsx.snap
+++ b/ui/src/containers/App/__snapshots__/App.test.tsx.snap
@@ -18,8 +18,8 @@ exports[`App should render the component correctly and match the snapshot 1`] = 
                   <header role={[undefined]} className=\\"pf-c-page__header\\">
                     <div className=\\"pf-c-page__header-brand\\">
                       <a className=\\"pf-c-page__header-brand-link\\">
-                        <Brand src=\\"logo.png\\" alt=\\"Tekton Hub Logo\\" onClick={[Function: onClick]}>
-                          <img onClick={[Function: onClick]} className=\\"pf-c-brand\\" src=\\"logo.png\\" alt=\\"Tekton Hub Logo\\" />
+                        <Brand src=\\"logo.png\\" alt=\\"Tekton Hub Logo\\" onClick={[Function: homePage]}>
+                          <img onClick={[Function: homePage]} className=\\"pf-c-brand\\" src=\\"logo.png\\" alt=\\"Tekton Hub Logo\\" />
                         </Brand>
                       </a>
                     </div>

--- a/ui/src/containers/Details/index.tsx
+++ b/ui/src/containers/Details/index.tsx
@@ -8,6 +8,7 @@ import Description from '../../components/Description';
 import { assert } from '../../store/utils';
 import { PageNotFound } from '../../components/PageNotFound';
 import { titleCase } from '../../common/titlecase';
+import { scrollToTop } from '../../common/scrollToTop';
 
 const Details: React.FC = () => {
   const { resources, user } = useMst();
@@ -25,12 +26,6 @@ const Details: React.FC = () => {
     const resource = resources.resources.get(resourceKey);
     assert(resource);
     user.getRating(resource.id);
-  };
-
-  const scrollToTop = () => {
-    const scroller = document.querySelector('main');
-    assert(scroller);
-    if (scroller) scroller.scrollTo(0, 0);
   };
 
   return useObserver(() =>

--- a/ui/src/containers/Header/__snapshots__/Header.test.tsx.snap
+++ b/ui/src/containers/Header/__snapshots__/Header.test.tsx.snap
@@ -10,8 +10,8 @@ exports[`Header should render the header component and find Search component 1`]
           <header role={[undefined]} className=\\"pf-c-page__header\\">
             <div className=\\"pf-c-page__header-brand\\">
               <a className=\\"pf-c-page__header-brand-link\\">
-                <Brand src=\\"logo.png\\" alt=\\"Tekton Hub Logo\\" onClick={[Function: onClick]}>
-                  <img onClick={[Function: onClick]} className=\\"pf-c-brand\\" src=\\"logo.png\\" alt=\\"Tekton Hub Logo\\" />
+                <Brand src=\\"logo.png\\" alt=\\"Tekton Hub Logo\\" onClick={[Function: homePage]}>
+                  <img onClick={[Function: homePage]} className=\\"pf-c-brand\\" src=\\"logo.png\\" alt=\\"Tekton Hub Logo\\" />
                 </Brand>
               </a>
             </div>

--- a/ui/src/containers/Header/index.tsx
+++ b/ui/src/containers/Header/index.tsx
@@ -16,6 +16,7 @@ import Search from '../../containers/Search';
 import UserProfile from '../UserProfile';
 import { useMst } from '../../store/root';
 import './Header.css';
+import { scrollToTop } from '../../common/scrollToTop';
 
 const Header: React.FC = observer(() => {
   const { user } = useMst();
@@ -40,10 +41,15 @@ const Header: React.FC = observer(() => {
     </PageHeaderTools>
   );
 
+  const homePage = () => {
+    if (!window.location.search) history.push('/');
+    scrollToTop();
+  };
+
   return (
     <React.Fragment>
       <PageHeader
-        logo={<Brand src={logo} alt="Tekton Hub Logo" onClick={() => history.push('/')} />}
+        logo={<Brand src={logo} alt="Tekton Hub Logo" onClick={homePage} />}
         headerTools={headerTools}
       />
     </React.Fragment>


### PR DESCRIPTION
This patch includes following changes

- Moves `scrollToTop` function to common folder since it is reusabe
- When user clicks on Hub logo it scroll to top of home page if
  they are on the home page otherwise redirects to home page

Signed-off-by: Shiv Verma <shverma@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._

