### PR TITLE
Reads Hub API Server URL from '.tekton/hub-config'  if present

### DIFF
--- a/api/pkg/cli/cmd/root.go
+++ b/api/pkg/cli/cmd/root.go
@@ -25,7 +25,6 @@ import (
 	"github.com/tektoncd/hub/api/pkg/cli/cmd/reinstall"
 	"github.com/tektoncd/hub/api/pkg/cli/cmd/search"
 	"github.com/tektoncd/hub/api/pkg/cli/cmd/upgrade"
-	"github.com/tektoncd/hub/api/pkg/cli/hub"
 )
 
 // Root represents the base command when called without any subcommands
@@ -59,7 +58,7 @@ func Root(cli app.CLI) *cobra.Command {
 		check_upgrade.Command(cli),
 	)
 
-	cmd.PersistentFlags().StringVar(&apiURL, "api-server", hub.URL(), "Hub API Server URL")
+	cmd.PersistentFlags().StringVar(&apiURL, "api-server", "", "Hub API Server URL (default 'https://api.hub.tekton.dev').\nURL can also be defined in a file '$HOME/.tekton/hub-config' with a variable 'HUB_API_SERVER'.")
 
 	return cmd
 }

--- a/api/pkg/cli/hub/hub.go
+++ b/api/pkg/cli/hub/hub.go
@@ -19,11 +19,16 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os/user"
+
+	"github.com/joho/godotenv"
+	"github.com/spf13/viper"
 )
 
 const (
 	// hubURL - Hub API Server URL
 	hubURL = "https://api.hub.tekton.dev"
+	hubConfigPath = ".tekton/hub-config"
 )
 
 type Client interface {
@@ -53,14 +58,32 @@ func URL() string {
 }
 
 // SetURL validates and sets the hub apiURL server URL
+// URL passed through flag will take precedence over the hub API URL
+// in config file and default URL
 func (h *client) SetURL(apiURL string) error {
 
-	_, err := url.ParseRequestURI(apiURL)
-	if err != nil {
+	if apiURL != "" {
+		_, err := url.ParseRequestURI(apiURL)
+		if err != nil {
+			return err
+		}
+		h.apiURL = apiURL
+		return nil
+	}
+
+	if err := loadConfigFile(); err != nil {
 		return err
 	}
 
-	h.apiURL = apiURL
+	viper.AutomaticEnv()
+	if apiURL := viper.GetString("HUB_API_SERVER"); apiURL != "" {
+		_, err := url.ParseRequestURI(apiURL)
+		if err != nil {
+			return fmt.Errorf("invalid url set for HUB_API_SERVER: %s : %v", apiURL, err)
+		}
+		h.apiURL = apiURL
+	}
+
 	return nil
 }
 
@@ -87,6 +110,12 @@ func (h *client) Get(endpoint string) ([]byte, int, error) {
 
 // httpGet gets raw data given the url
 func httpGet(url string) ([]byte, int, error) {
+
+	err := loadConfigFile()
+	if err != nil {
+		return nil, 0, err
+	}
+
 	resp, err := http.Get(url)
 	if err != nil {
 		return nil, 0, err
@@ -99,4 +128,22 @@ func httpGet(url string) ([]byte, int, error) {
 	}
 
 	return data, resp.StatusCode, err
+}
+
+// Looks for config file at $HOME/.tekton/hub-config and loads into
+// in the environment
+func loadConfigFile() error {
+
+	user, err := user.Current()
+	if err != nil {
+		return err
+	}
+
+	// if hub-config file not found, then returns
+	path := fmt.Sprintf("%s/%s", user.HomeDir, hubConfigPath)
+	if err := godotenv.Load(path); err != nil {
+		return nil
+	}
+
+	return nil
 }


### PR DESCRIPTION
This adds support for reading `HUB_API_SERVER` URL from a file
at location $HOME/.tekton/hub-config.
If url is not flag is not as passed, it will check in hub-config file,
if still not defined then it will use default url.
URL passed by flag will get priority over URL in hub-config and default
URL.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

# Submitter Checklist


These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._

