### PR TITLE
UI: Improves url link in the resource README

### DIFF
--- a/ui/src/components/Description/index.tsx
+++ b/ui/src/components/Description/index.tsx
@@ -26,6 +26,34 @@ const Description: React.FC<Props> = (props) => {
   const { catalog, kind, name } = props;
   const resource = resources.resources.get(`${catalog}/${titleCase(kind)}/${name}`);
 
+  const { webURL, version } = resource.displayVersion;
+
+  const resourceDirUrl = webURL.slice(0, webURL.indexOf(name));
+  const resourceWebUrl = resourceDirUrl + `${name}`;
+
+  // This function transform relative uri of readme into absoulte uri
+  const transformUri = (uri: string) => {
+    if (!uri.includes('./') && !uri.includes('http')) {
+      return resourceWebUrl + `/${version}/${uri}`;
+    }
+
+    if (uri.includes('./')) {
+      const uriPath = uri.slice(uri.lastIndexOf('./') + 1);
+
+      if (uri.includes('../../')) {
+        return resourceDirUrl + uriPath;
+      }
+
+      if (!/\d/.test(uriPath.slice(0, 3))) {
+        return resourceWebUrl + `/${version}${uriPath}`;
+      }
+
+      return resourceWebUrl + uriPath;
+    }
+
+    return uri;
+  };
+
   return useObserver(() =>
     resource.readme === '' || resource.yaml === '' ? (
       <Spinner className="hub-details-spinner" />
@@ -41,6 +69,8 @@ const Description: React.FC<Props> = (props) => {
                       <Tab eventKey={0} title="Description" id={props.name}>
                         <hr className="hub-horizontal-line"></hr>
                         <ReactMarkDown
+                          linkTarget={' '}
+                          transformLinkUri={(uri: string) => transformUri(uri)}
                           plugins={[[gfm, { tablePipeAlign: false }]]}
                           source={resource.readme}
                           escapeHtml={true}


### PR DESCRIPTION
- Adds blank target to every link of README
  iorder to open it in a new tab
- Replace relative url with absolute url

* Deployed link : https://ui-tekton-hub.apps.cluster-6d97.6d97.sandbox1266.opentlc.com/

Signed-off-by: Shiv Verma <shverma@redhat.com'

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._

