### PR TITLE
Adds an ingress to redirect from Hub Preview to Hub

### DIFF
--- a/config/04-kubernetes/42-hub-preview-redirect-ingress.yaml
+++ b/config/04-kubernetes/42-hub-preview-redirect-ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: redirect-to-tekton-hub
+  namespace: tekton-hub-preview
+  annotations:
+    acme.cert-manager.io/http01-edit-in-place: 'true'
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/permanent-redirect: https://hub.tekton.dev
+    nginx.ingress.kubernetes.io/force-ssl-redirect: 'true'
+    dns.gardener.cloud/dnsnames: hub-preview.tekton.dev
+    dns.gardener.cloud/ttl: '3600'
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  tls:
+    - secretName: ui-hub-preview-tekton-dev-tls
+      hosts: [hub-preview.tekton.dev]
+  rules:
+    - host: hub-preview.tekton.dev
+      http:
+        paths:
+          - path: /*
+            backend:
+              serviceName: ui
+              servicePort: 8080


### PR DESCRIPTION
  - This patch adds an annotation which redirects from Hub Preview to Hub as
    `nginx.ingress.kubernetes.io/permanent-redirect: https://hub.tekton.dev`

Signed-off-by: Puneet Punamiya <ppunamiy@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._

