### PR TITLE
Add github enterprise support

### DIFF
--- a/api/.env.dev
+++ b/api/.env.dev
@@ -12,5 +12,6 @@ GH_CLIENT_SECRET="client-secret"
 JWT_SIGNING_KEY="TektonHub"
 ACCESS_JWT_EXPIRES_IN="1s"
 REFRESH_JWT_EXPIRES_IN="1s"
+GHE_URL=""
 
 CONFIG_FILE_URL="file://../config.yaml"

--- a/api/pkg/service/catalog/catalog_http_test.go
+++ b/api/pkg/service/catalog/catalog_http_test.go
@@ -101,7 +101,7 @@ func TestRefreshAll_Http(t *testing.T) {
 		marshallErr := json.Unmarshal([]byte(b), &res)
 		assert.NoError(t, marshallErr)
 
-		assert.Equal(t, 2, len(res))
+		assert.Equal(t, 3, len(res))
 	})
 }
 

--- a/api/pkg/service/catalog/catalog_test.go
+++ b/api/pkg/service/catalog/catalog_test.go
@@ -113,12 +113,14 @@ func TestRefresh_All(t *testing.T) {
 	payload := &catalog.RefreshAllPayload{}
 	jobs, err := catalogSvc.RefreshAll(ctx, payload)
 	assert.NoError(t, err)
-	assert.Equal(t, 2, len(jobs))
+	assert.Equal(t, 3, len(jobs))
 
-	assert.Contains(t, []string{"catalog-official", "catalog-community"}, jobs[0].CatalogName)
+	assert.Contains(t, []string{"catalog-official", "catalog-community", "catalog-enterprise"}, jobs[0].CatalogName)
 	assert.Equal(t, "queued", jobs[0].Status)
-	assert.Contains(t, []string{"catalog-official", "catalog-community"}, jobs[1].CatalogName)
+	assert.Contains(t, []string{"catalog-official", "catalog-community", "catalog-enterprise"}, jobs[1].CatalogName)
 	assert.Equal(t, "queued", jobs[1].Status)
+	assert.Contains(t, []string{"catalog-official", "catalog-community", "catalog-enterprise"}, jobs[2].CatalogName)
+	assert.Equal(t, "queued", jobs[2].Status)
 }
 
 func TestCatalogError(t *testing.T) {

--- a/api/pkg/service/resource/resource_http_test.go
+++ b/api/pkg/service/resource/resource_http_test.go
@@ -412,6 +412,23 @@ func TestByCatalogKindName_Http(t *testing.T) {
 	})
 }
 
+func TestByEnterpriseCatalogKindName_Http(t *testing.T) {
+	tc := testutils.Setup(t)
+	testutils.LoadFixtures(t, tc.FixturePath())
+
+	ByCatalogKindNameChecker(tc).Test(t, http.MethodGet, "/resource/catalog-enterprise/task/tkn-enterprise").Check().
+		HasStatus(200).Cb(func(r *http.Response) {
+		b, readErr := ioutil.ReadAll(r.Body)
+		assert.NoError(t, readErr)
+		defer r.Body.Close()
+
+		res, err := testutils.FormatJSON(b)
+		assert.NoError(t, err)
+
+		golden.Assert(t, res, fmt.Sprintf("%s.golden", t.Name()))
+	})
+}
+
 func TestByCatalogKindName_CompatibleVersion_Http(t *testing.T) {
 	tc := testutils.Setup(t)
 	testutils.LoadFixtures(t, tc.FixturePath())

--- a/api/pkg/service/resource/resource_test.go
+++ b/api/pkg/service/resource/resource_test.go
@@ -147,6 +147,17 @@ func TestByCatalogKindName(t *testing.T) {
 	assert.Equal(t, "img", res.Data.Name)
 }
 
+func TestByEnterpriseCatalogKindName(t *testing.T) {
+	tc := testutils.Setup(t)
+	testutils.LoadFixtures(t, tc.FixturePath())
+
+	resourceSvc := New(tc)
+	payload := &resource.ByCatalogKindNamePayload{Catalog: "catalog-enterprise", Kind: "task", Name: "tkn-enterprise"}
+	res, err := resourceSvc.ByCatalogKindName(context.Background(), payload)
+	assert.NoError(t, err)
+	assert.Equal(t, "tkn-enterprise", res.Data.Name)
+}
+
 func TestByCatalogKindNameIfCompatible(t *testing.T) {
 	tc := testutils.Setup(t)
 	testutils.LoadFixtures(t, tc.FixturePath())
@@ -204,4 +215,12 @@ func TestByID_NotFoundError(t *testing.T) {
 	_, err := resourceSvc.ByID(context.Background(), payload)
 	assert.Error(t, err)
 	assert.EqualError(t, err, "resource not found")
+}
+
+func TestCreationRawURL(t *testing.T) {
+	url := "https://ghe.myhost.com/org/repo/tree/main/task/name/0.1/name.yaml"
+	replacer := getStringReplacer(url)
+	rawUrl := replacer.Replace(url)
+	expected := "https://raw.ghe.myhost.com/org/repo/main/task/name/0.1/name.yaml"
+	assert.Equal(t, expected, rawUrl)
 }

--- a/api/pkg/service/resource/testdata/TestByEnterpriseCatalogKindName_Http.golden
+++ b/api/pkg/service/resource/testdata/TestByEnterpriseCatalogKindName_Http.golden
@@ -1,0 +1,35 @@
+{
+	"data": {
+		"id": 8,
+		"name": "tkn-enterprise",
+		"catalog": {
+			"id": 3,
+			"name": "catalog-enterprise",
+			"type": "enterprise"
+		},
+		"kind": "task",
+		"latestVersion": {
+			"id": 11,
+			"version": "0.1",
+			"displayName": "Tkn EnterpriseTask",
+			"description": "Desc8",
+			"minPipelinesVersion": "0.12.1",
+			"rawURL": "https://raw.myghe.com/Pipelines-Marketplace/catalog-community/master/task/tkn-enterprise/0.1/tkn-enterprise.yaml",
+			"webURL": "https://myghe.com/Pipelines-Marketplace/catalog-community/tree/master/task/tkn-enterprise/0.1/tkn-enterprise.yaml",
+			"updatedAt": "2013-01-01T00:00:01Z"
+		},
+		"tags": [
+			{
+				"id": 2,
+				"name": "rtag"
+			}
+		],
+		"rating": 5,
+		"versions": [
+			{
+				"id": 11,
+				"version": "0.1"
+			}
+		]
+	}
+}

--- a/api/pkg/service/resource/testdata/TestList_Http_NoLimit.golden
+++ b/api/pkg/service/resource/testdata/TestList_Http_NoLimit.golden
@@ -55,6 +55,33 @@
 			"rating": 5
 		},
 		{
+			"id": 8,
+			"name": "tkn-enterprise",
+			"catalog": {
+				"id": 3,
+				"name": "catalog-enterprise",
+				"type": "enterprise"
+			},
+			"kind": "task",
+			"latestVersion": {
+				"id": 11,
+				"version": "0.1",
+				"displayName": "Tkn EnterpriseTask",
+				"description": "Desc8",
+				"minPipelinesVersion": "0.12.1",
+				"rawURL": "https://raw.myghe.com/Pipelines-Marketplace/catalog-community/master/task/tkn-enterprise/0.1/tkn-enterprise.yaml",
+				"webURL": "https://myghe.com/Pipelines-Marketplace/catalog-community/tree/master/task/tkn-enterprise/0.1/tkn-enterprise.yaml",
+				"updatedAt": "2013-01-01T00:00:01Z"
+			},
+			"tags": [
+				{
+					"id": 2,
+					"name": "rtag"
+				}
+			],
+			"rating": 5
+		},
+		{
 			"id": 7,
 			"name": "tkn-hub",
 			"catalog": {

--- a/api/pkg/shared/resource/resource_test.go
+++ b/api/pkg/shared/resource/resource_test.go
@@ -35,7 +35,7 @@ func TestQuery_DefaultLimit(t *testing.T) {
 
 	res, err := req.Query()
 	assert.NoError(t, err)
-	assert.Equal(t, 7, len(res))
+	assert.Equal(t, 8, len(res))
 }
 
 func TestQuery_ByLimit(t *testing.T) {
@@ -121,7 +121,7 @@ func TestQuery_ByMultipleKinds(t *testing.T) {
 
 	res, err := req.Query()
 	assert.NoError(t, err)
-	assert.Equal(t, 7, len(res))
+	assert.Equal(t, 8, len(res))
 }
 
 func TestQuery_ByTags(t *testing.T) {

--- a/api/test/fixtures/catalogs.yaml
+++ b/api/test/fixtures/catalogs.yaml
@@ -31,3 +31,13 @@
   revision: master
   created_at: 2016-01-01 12:30:12 UTC
   updated_at: 2016-01-01 12:30:12 UTC
+
+- id: 3
+  name: catalog-enterprise
+  org: tektoncd
+  type: enterprise
+  url: https:/myghe.com/tektoncd/catalog-enterprise
+  context_dir: /task
+  revision: master
+  created_at: 2016-01-01 12:30:12 UTC
+  updated_at: 2016-01-01 12:30:12 UTC

--- a/api/test/fixtures/resource_tags.yaml
+++ b/api/test/fixtures/resource_tags.yaml
@@ -32,3 +32,6 @@
 
 - resource_id: 7
   tag_id: 2
+
+- resource_id: 8
+  tag_id: 2

--- a/api/test/fixtures/resource_versions.yaml
+++ b/api/test/fixtures/resource_versions.yaml
@@ -122,3 +122,14 @@
   created_at: 2016-01-01 12:30:12 UTC
   updated_at: 2016-01-01 12:30:12 UTC
   modified_at: 2013-01-01 00:00:01 UTC
+
+- id: 11
+  version: "0.1"
+  display_name: Tkn EnterpriseTask
+  description: Desc8
+  min_pipelines_version: 0.12.1
+  url: https://myghe.com/Pipelines-Marketplace/catalog-community/tree/master/task/tkn-enterprise/0.1/tkn-enterprise.yaml
+  resource_id: 8
+  created_at: 2016-01-01 12:30:12 UTC
+  updated_at: 2016-01-01 12:30:12 UTC
+  modified_at: 2013-01-01 00:00:01 UTC

--- a/api/test/fixtures/resources.yaml
+++ b/api/test/fixtures/resources.yaml
@@ -67,3 +67,11 @@
   catalog_id: 1
   created_at: 2016-01-01 12:30:12 UTC
   updated_at: 2016-01-01 12:30:12 UTC
+
+- id: 8
+  name: tkn-enterprise
+  kind: task
+  rating: 5
+  catalog_id: 3
+  created_at: 2016-01-01 12:30:12 UTC
+  updated_at: 2016-01-01 12:30:12 UTC

--- a/api/v1/service/catalog/catalog_test.go
+++ b/api/v1/service/catalog/catalog_test.go
@@ -30,6 +30,6 @@ func TestCatalog_List(t *testing.T) {
 	all, err := catalog.List(context.Background())
 
 	assert.NoError(t, err)
-	assert.Equal(t, 2, len(all.Data))
+	assert.Equal(t, 3, len(all.Data))
 
 }

--- a/api/v1/service/catalog/testdata/TestCatalog_List_Http.golden
+++ b/api/v1/service/catalog/testdata/TestCatalog_List_Http.golden
@@ -11,6 +11,12 @@
 			"name": "catalog-community",
 			"type": "community",
 			"url": "https:/github.com/tektoncd/catalog-community"
+		},
+		{
+			"id": 3,
+			"name": "catalog-enterprise",
+			"type": "enterprise",
+			"url": "https:/myghe.com/tektoncd/catalog-enterprise"
 		}
 	]
 }

--- a/api/v1/service/resource/resource_http_test.go
+++ b/api/v1/service/resource/resource_http_test.go
@@ -412,6 +412,23 @@ func TestByCatalogKindName_Http(t *testing.T) {
 	})
 }
 
+func TestByEnterpriseCatalogKindName_Http(t *testing.T) {
+	tc := testutils.Setup(t)
+	testutils.LoadFixtures(t, tc.FixturePath())
+
+	ByCatalogKindNameChecker(tc).Test(t, http.MethodGet, "/v1/resource/catalog-enterprise/task/tkn-enterprise").Check().
+		HasStatus(200).Cb(func(r *http.Response) {
+		b, readErr := ioutil.ReadAll(r.Body)
+		assert.NoError(t, readErr)
+		defer r.Body.Close()
+
+		res, err := testutils.FormatJSON(b)
+		assert.NoError(t, err)
+
+		golden.Assert(t, res, fmt.Sprintf("%s.golden", t.Name()))
+	})
+}
+
 func TestByCatalogKindName_CompatibleVersion_Http(t *testing.T) {
 	tc := testutils.Setup(t)
 	testutils.LoadFixtures(t, tc.FixturePath())

--- a/api/v1/service/resource/resource_test.go
+++ b/api/v1/service/resource/resource_test.go
@@ -147,6 +147,17 @@ func TestByCatalogKindName(t *testing.T) {
 	assert.Equal(t, "img", res.Data.Name)
 }
 
+func TestByEnterpriseCatalogKindName(t *testing.T) {
+	tc := testutils.Setup(t)
+	testutils.LoadFixtures(t, tc.FixturePath())
+
+	resourceSvc := New(tc)
+	payload := &resource.ByCatalogKindNamePayload{Catalog: "catalog-enterprise", Kind: "task", Name: "tkn-enterprise"}
+	res, err := resourceSvc.ByCatalogKindName(context.Background(), payload)
+	assert.NoError(t, err)
+	assert.Equal(t, "tkn-enterprise", res.Data.Name)
+}
+
 func TestByCatalogKindNameIfCompatible(t *testing.T) {
 	tc := testutils.Setup(t)
 	testutils.LoadFixtures(t, tc.FixturePath())
@@ -204,4 +215,12 @@ func TestByID_NotFoundError(t *testing.T) {
 	_, err := resourceSvc.ByID(context.Background(), payload)
 	assert.Error(t, err)
 	assert.EqualError(t, err, "resource not found")
+}
+
+func TestCreationRawURL(t *testing.T) {
+	url := "https://ghe.myhost.com/org/repo/tree/main/task/name/0.1/name.yaml"
+	replacer := getStringReplacer(url)
+	rawUrl := replacer.Replace(url)
+	expected := "https://raw.ghe.myhost.com/org/repo/main/task/name/0.1/name.yaml"
+	assert.Equal(t, expected, rawUrl)
 }

--- a/api/v1/service/resource/testdata/TestByEnterpriseCatalogKindName_Http.golden
+++ b/api/v1/service/resource/testdata/TestByEnterpriseCatalogKindName_Http.golden
@@ -1,0 +1,35 @@
+{
+	"data": {
+		"id": 8,
+		"name": "tkn-enterprise",
+		"catalog": {
+			"id": 3,
+			"name": "catalog-enterprise",
+			"type": "enterprise"
+		},
+		"kind": "task",
+		"latestVersion": {
+			"id": 11,
+			"version": "0.1",
+			"displayName": "Tkn EnterpriseTask",
+			"description": "Desc8",
+			"minPipelinesVersion": "0.12.1",
+			"rawURL": "https://raw.myghe.com/Pipelines-Marketplace/catalog-community/master/task/tkn-enterprise/0.1/tkn-enterprise.yaml",
+			"webURL": "https://myghe.com/Pipelines-Marketplace/catalog-community/tree/master/task/tkn-enterprise/0.1/tkn-enterprise.yaml",
+			"updatedAt": "2013-01-01T00:00:01Z"
+		},
+		"tags": [
+			{
+				"id": 2,
+				"name": "rtag"
+			}
+		],
+		"rating": 5,
+		"versions": [
+			{
+				"id": 11,
+				"version": "0.1"
+			}
+		]
+	}
+}

--- a/api/v1/service/resource/testdata/TestList_Http_NoLimit.golden
+++ b/api/v1/service/resource/testdata/TestList_Http_NoLimit.golden
@@ -55,6 +55,33 @@
 			"rating": 5
 		},
 		{
+			"id": 8,
+			"name": "tkn-enterprise",
+			"catalog": {
+				"id": 3,
+				"name": "catalog-enterprise",
+				"type": "enterprise"
+			},
+			"kind": "task",
+			"latestVersion": {
+				"id": 11,
+				"version": "0.1",
+				"displayName": "Tkn EnterpriseTask",
+				"description": "Desc8",
+				"minPipelinesVersion": "0.12.1",
+				"rawURL": "https://raw.myghe.com/Pipelines-Marketplace/catalog-community/master/task/tkn-enterprise/0.1/tkn-enterprise.yaml",
+				"webURL": "https://myghe.com/Pipelines-Marketplace/catalog-community/tree/master/task/tkn-enterprise/0.1/tkn-enterprise.yaml",
+				"updatedAt": "2013-01-01T00:00:01Z"
+			},
+			"tags": [
+				{
+					"id": 2,
+					"name": "rtag"
+				}
+			],
+			"rating": 5
+		},
+		{
 			"id": 7,
 			"name": "tkn-hub",
 			"catalog": {

--- a/config/02-api/20-api-secret.yaml
+++ b/config/02-api/20-api-secret.yaml
@@ -9,3 +9,4 @@ stringData:
   JWT_SIGNING_KEY: ''
   ACCESS_JWT_EXPIRES_IN: ''
   REFRESH_JWT_EXPIRES_IN: ''
+  GHE_URL: ''

--- a/config/02-api/22-api-deployment.yaml
+++ b/config/02-api/22-api-deployment.yaml
@@ -104,3 +104,8 @@ spec:
                 secretKeyRef:
                   name: api
                   key: REFRESH_JWT_EXPIRES_IN
+            - name: GHE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: api
+                  key: GHE_URL

--- a/config/03-ui/30-ui-configmap.yaml
+++ b/config/03-ui/30-ui-configmap.yaml
@@ -7,3 +7,4 @@ data:
   API_URL: 'https://api.hub.tekton.dev'
   GH_CLIENT_ID: ''
   API_VERSION: ''
+  GHE_URL: ''

--- a/config/03-ui/31-ui-deployment.yaml
+++ b/config/03-ui/31-ui-deployment.yaml
@@ -19,6 +19,11 @@ spec:
         - name: ui
           image: quay.io/tekton-hub/ui
           env:
+            - name: GHE_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: ui
+                  key: GHE_URL
             - name: API_URL
               valueFrom:
                 configMapKeyRef:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -74,6 +74,10 @@ eg. `quay.io/<username>/db-migration`
 
 Make sure all images are public before creating deployments.
 
+---
+> ### NOTE: In case of using Github Enterprise make sure you deploy Hub in the same network where Github Enterprise server is running. Example if your Github Enterprise is running behind VPN then your Kubernetes Cluster should also be behind VPN.
+---
+
 ## Deploy Database
 
 Now, we have all images pushed to registry. Lets deploy the database first.
@@ -148,6 +152,7 @@ stringData:
   JWT_SIGNING_KEY: a-long-signing-key
   ACCESS_JWT_EXPIRES_IN: time such as 15m
   REFRESH_JWT_EXPIRES_IN: time such as 15m
+  GHE_URL: Add Github Enterprise URL in case of authenticating through Github Enterprise (Example (https|http)://myghe.com) --> Do not provide the catalog URL
 ```
 
 ### Update API ConfigMap
@@ -258,6 +263,7 @@ data:
   API_URL: API URL   <<< Update this by API url
   GH_CLIENT_ID: GH OAuth Client ID   <<< Update this OAuth client id
   API_VERSION: API VERSION  <<< Update this by API version (For e.g-"v1")
+  GHE_URL: Github Enterprise URL <<< Update this if you are getting logged in via Github Enterprise
 ```
 
 ### Update UI Image
@@ -326,7 +332,7 @@ Update your GitHub OAuth created with the UI route in place of `Homepage URL` an
 
 ## Add resources in DB
 
-1. Login through the Hub UI. Click on `Login` on right corner and then `Sign in with GitHub`.
+1. Login through the Hub UI. Click on `Login` on right corner and then `Sign in with GitHub/Github Enterprise`.
 
 2. Copy the Hub Token by clicking on the user profile which is at the right corner on the Home Page
 

--- a/ui/image/start.sh
+++ b/ui/image/start.sh
@@ -15,6 +15,7 @@ window.config = {
   API_URL: '$API_URL',
   GH_CLIENT_ID: '$GH_CLIENT_ID',
   API_VERSION: '$API_VERSION',
+  GHE_URL: '$GHE_URL',
 };
 
 

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -15693,10 +15693,10 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
       "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew=="
     },
-    "react-github-login": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/react-github-login/-/react-github-login-1.0.3.tgz",
-      "integrity": "sha1-4/3CnBFi7MBwTZ/mCWxp1vUzFec="
+    "react-ghe-login": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/react-ghe-login/-/react-ghe-login-1.2.0.tgz",
+      "integrity": "sha512-Att76hw4cFLYdGE9lUArGxMVxOiCaN5L/7N8Pl/3WMtYtswosXY7UDxV5OPVOEIxtkJfrGrNxjbSx6jWo4iXgw=="
     },
     "react-hotkeys-hook": {
       "version": "3.3.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -25,7 +25,7 @@
     "mst-persist": "^0.1.3",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "react-github-login": "^1.0.3",
+    "react-ghe-login": "^1.2.0",
     "react-hotkeys-hook": "^3.3.1",
     "react-markdown": "^5.0.3",
     "react-router-dom": "^5.2.0",

--- a/ui/public/config.js
+++ b/ui/public/config.js
@@ -1,5 +1,6 @@
 window.config = {
   API_URL: 'https://api.hub.tekton.dev',
   GH_CLIENT_ID: '',
-  API_VERSION: 'v1'
+  API_VERSION: 'v1',
+  GHE_URL: '',
 };

--- a/ui/src/config/constant.d.ts
+++ b/ui/src/config/constant.d.ts
@@ -2,6 +2,7 @@ interface API_CONFIG {
   API_URL: string;
   GH_CLIENT_ID: string;
   API_VERSION: string;
+  GHE_URL: string;
 }
 
 export declare global {

--- a/ui/src/config/constants.tsx
+++ b/ui/src/config/constants.tsx
@@ -6,3 +6,4 @@ window.config = window.config || {
 export const API_URL = window.config.API_URL;
 export const GH_CLIENT_ID = window.config.GH_CLIENT_ID;
 export const API_VERSION = window.config.API_VERSION;
+export const GHE_URL = window.config.GHE_URL;

--- a/ui/src/containers/Authentication/Authentication.test.tsx
+++ b/ui/src/containers/Authentication/Authentication.test.tsx
@@ -2,7 +2,7 @@ import { Card } from '@patternfly/react-core';
 import { mount, shallow } from 'enzyme';
 import React from 'react';
 import renderer from 'react-test-renderer';
-import GitHubLogin from 'react-github-login';
+import GitHubLogin from 'react-ghe-login';
 import Authentication from '.';
 import { FakeHub } from '../../api/testutil';
 import { createProviderAndStore } from '../../store/root';

--- a/ui/src/containers/Authentication/index.tsx
+++ b/ui/src/containers/Authentication/index.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import GitHubLogin from 'react-github-login';
+import GitHubLogin from 'react-ghe-login';
 import { useHistory } from 'react-router-dom';
 import { observer } from 'mobx-react';
 import { Card, CardBody, CardHeader, AlertVariant } from '@patternfly/react-core';
-import { GH_CLIENT_ID } from '../../config/constants';
+import { GHE_URL, GH_CLIENT_ID } from '../../config/constants';
 import { useMst } from '../../store/root';
 import { AuthCodeProps } from '../../store/auth';
 import { Icons } from '../../common/icons';
@@ -34,6 +34,7 @@ const Authentication: React.FC = observer(() => {
             redirectUri=""
             onSuccess={onSuccess}
             onFailure={user.onFailure}
+            host={GHE_URL || 'https://github.com'}
           />
         </CardBody>
       </Card>

--- a/ui/src/react-app-env.d.ts
+++ b/ui/src/react-app-env.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="react-scripts" />
-declare module 'react-github-login';
+declare module 'react-ghe-login';


### PR DESCRIPTION
# Changes

### API
- Read enterprise url from env and if not provided default to github.com
- Configure oauth2 on the basis of github host
- Create enterprise client in case of enterprise auth else normal github client
- generate raw url of the resource on the basis web url provided
- update the deployment manifests

### UI
- update the deployment manifests
- read enterprise url from env
- use `react-ghe-login` in place of `react-github-login`

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._

