### PR TITLE
Fetch installed tekton component version from ConfigMap

### DIFF
--- a/api/pkg/cli/test/helpers.go
+++ b/api/pkg/cli/test/helpers.go
@@ -68,6 +68,25 @@ func GetDeploymentData(name, version string) *unstructured.Unstructured {
 	return deployment
 }
 
+func GetConfigMapData(name string, version string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]interface{}{
+				"name": name,
+				"labels": map[string]interface{}{
+					"app.kubernetes.io/part-of":  "tekton-pipelines",
+					"app.kubernetes.io/instance": "default",
+				},
+			},
+			"data": map[string]interface{}{
+				"version": version,
+			},
+		},
+	}
+}
+
 func CreateTektonPipelineController(dynamic dynamic.Interface, version string) error {
 
 	deployment := GetDeploymentData("test", version)


### PR DESCRIPTION
# Changes

As part of TEP-0041 version of tekton pipelines will be stored in a new
ConfigMap and that ConfigMap is given special permissions so that in
heavy RBAC enforced environment any user authenticated to the cluster
can still fetch the version even if they don't have permissions to view
the other resources which are associated with tekton-pipelines.

With pipelines 0.25 version this configmap would be available so
fetching the version from configmap and if the configmap is not present
then it will check for the version present on the label (backward
compatible).

Signed-off-by: vinamra28 <vinjain@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._

