### PR TITLE
UI: Add search tips to helps in resources search

### DIFF
--- a/ui/src/common/icons.ts
+++ b/ui/src/common/icons.ts
@@ -8,5 +8,6 @@ export enum Icons {
   Star = 'star',
   Github = 'github',
   WarningTriangle = 'Warningtriangle',
-  Catalog = 'catalog'
+  Catalog = 'catalog',
+  Help = 'help'
 }

--- a/ui/src/components/Icon/index.tsx
+++ b/ui/src/components/Icon/index.tsx
@@ -9,7 +9,8 @@ import {
   StarIcon,
   GithubIcon,
   WarningTriangleIcon,
-  CatalogIcon
+  CatalogIcon,
+  HelpIcon
 } from '@patternfly/react-icons';
 import { Icons } from '../../common/icons';
 import './Icon.css';
@@ -43,6 +44,8 @@ const Icon: React.FC<Props> = (props: Props) => {
       return <WarningTriangleIcon size={size} className="hub-icon" label={label} />;
     case Icons.Catalog:
       return <CatalogIcon size={size} className="hub-icon" label={label} />;
+    case Icons.Help:
+      return <HelpIcon size={size} label={label} />;
   }
 };
 

--- a/ui/src/containers/App/__snapshots__/App.test.tsx.snap
+++ b/ui/src/containers/App/__snapshots__/App.test.tsx.snap
@@ -27,8 +27,8 @@ exports[`App should render the component correctly and match the snapshot 1`] = 
                       <div className=\\"pf-c-page__header-tools\\">
                         <Grid>
                           <div className=\\"pf-l-grid\\">
-                            <GridItem span={11}>
-                              <div className=\\"pf-l-grid__item pf-m-11-col\\">
+                            <GridItem span={10}>
+                              <div className=\\"pf-l-grid__item pf-m-10-col\\">
                                 <Memo(wrappedComponent)>
                                   <ForwardRef type=\\"search\\" value=\\"\\" onChange={[Function: onSearchChange]} onKeyPress={[Function: onSearchKeyPress]} aria-label=\\"text input example\\" placeholder=\\"Search for resources...\\" spellCheck=\\"false\\" className=\\"hub-search\\">
                                     <TextInputBase type=\\"search\\" value=\\"\\" onChange={[Function: onSearchChange]} onKeyPress={[Function: onSearchKeyPress]} aria-label=\\"text input example\\" placeholder=\\"Search for resources...\\" spellCheck=\\"false\\" className=\\"hub-search\\" innerRef={{...}} isRequired={false} validated=\\"default\\" isDisabled={false} isReadOnly={false} isLeftTruncated={false}>
@@ -36,6 +36,17 @@ exports[`App should render the component correctly and match the snapshot 1`] = 
                                     </TextInputBase>
                                   </ForwardRef>
                                 </Memo(wrappedComponent)>
+                              </div>
+                            </GridItem>
+                            <GridItem span={1} onClick={[Function: onClick]} className=\\"header-search-hint\\">
+                              <div className=\\"pf-l-grid__item pf-m-1-col header-search-hint\\" onClick={[Function: onClick]}>
+                                <Icon id=\\"help\\" size=\\"sm\\" label=\\"search-tips\\">
+                                  <HelpIcon size=\\"sm\\" label=\\"search-tips\\" color=\\"currentColor\\" noVerticalAlign={false}>
+                                    <svg style={{...}} fill=\\"currentColor\\" height=\\"1em\\" width=\\"1em\\" viewBox=\\"0 64 1024 1024\\" aria-labelledby={{...}} aria-hidden={true} role=\\"img\\" label=\\"search-tips\\">
+                                      <path d=\\"M512.059-73.143c-282.338 0-512.059 229.673-512.059 512.025 0 282.235 229.721 511.975 512.059 511.975 282.281 0 511.941-229.735 511.941-511.975 0.005-282.352-229.659-512.025-511.941-512.025zM512.059 826.523c-213.826 0-387.728-173.856-387.728-387.643 0-213.89 173.904-387.694 387.728-387.694 213.717 0 387.671 173.803 387.671 387.694 0.005 213.785-173.957 387.643-387.671 387.643zM585.143 164.571v109.714c0 4.951-1.808 9.237-5.429 12.857s-7.906 5.429-12.857 5.429h-109.714c-4.953 0-9.239-1.808-12.857-5.429s-5.429-7.906-5.429-12.857v-109.714c0-4.951 1.81-9.237 5.429-12.857s7.904-5.429 12.857-5.429h109.714c4.951 0 9.237 1.808 12.857 5.429s5.429 7.906 5.429 12.857zM521.616 365.714c118.343 0 214.286 88.965 214.286 187.429s-95.943 178.286-214.286 178.286c-173.045 0-208.091-93.714-213.963-171.113 0-7.936 6.729-9.838 15.872-9.838s108.073 0 113.143 0c6.096 0 14.475 0.633 17.554 10.571 0 48.857 135.968 54.953 135.968-7.904 0-31.506-29.717-63.817-68.571-66.194s-82.286-7.607-82.286-54.199c0-13.022 0-25.673 0-44.693 0-19.015 9.717-22.343 27.431-22.343s54.853-0.002 54.853-0.002z\\" transform=\\"rotate(180 0 512) scale(-1 1)\\" />
+                                    </svg>
+                                  </HelpIcon>
+                                </Icon>
                               </div>
                             </GridItem>
                           </div>
@@ -57,6 +68,11 @@ exports[`App should render the component correctly and match the snapshot 1`] = 
                     </PageHeaderTools>
                   </header>
                 </PageHeader>
+                <Modal variant=\\"small\\" title=\\"Search tips:\\" isOpen={false} onClose={[Function: onClose]} className=\\"\\" aria-label=\\"\\" showClose={true} aria-describedby=\\"\\" aria-labelledby=\\"\\" id={[undefined]} actions={{...}} hasNoBodyWrapper={false} appendTo={[Function: appendTo]} ouiaSafe={true}>
+                  <Portal containerInfo={{...}}>
+                    <ModalContent variant=\\"small\\" isOpen={false} onClose={[Function: onClose]} className=\\"\\" showClose={true} id={[undefined]} actions={{...}} hasNoBodyWrapper={false} boxId=\\"pf-modal-part-0\\" labelId=\\"pf-modal-part-1\\" descriptorId=\\"pf-modal-part-2\\" title=\\"Search tips:\\" aria-label=\\"\\" aria-describedby=\\"\\" aria-labelledby=\\"\\" ouiaId={[undefined]} ouiaSafe={true} />
+                  </Portal>
+                </Modal>
               </Memo(wrappedComponent)>
               <main role={[undefined]} id={[undefined]} className=\\"pf-c-page__main\\" tabIndex={-1} aria-label={[undefined]}>
                 <Route exact={true} path=\\"/\\" component={[Function: Background]}>

--- a/ui/src/containers/Header/Header.css
+++ b/ui/src/containers/Header/Header.css
@@ -1,4 +1,10 @@
 .hub-header-login {
   color: white;
-  fontsize: 1em;
+  font-size: 1em;
+}
+
+.header-search-hint svg {
+  vertical-align: 0em !important;
+  margin-left: 0.2em;
+  cursor: pointer;
 }

--- a/ui/src/containers/Header/Header.test.tsx
+++ b/ui/src/containers/Header/Header.test.tsx
@@ -8,6 +8,8 @@ import UserProfile from '../UserProfile';
 import { FakeHub } from '../../api/testutil';
 import { createProviderAndStore } from '../../store/root';
 import { ActualDate, FakeDate } from '../../common/testutils';
+import Icon from '../../components/Icon';
+import { Icons } from '../../common/icons';
 
 const TESTDATA_DIR = `src/store/testdata`;
 const api = new FakeHub(TESTDATA_DIR);
@@ -42,6 +44,19 @@ describe('Header', () => {
       </Provider>
     );
     expect(component.find('span').text()).toBe('Login');
+  });
+
+  it('should find Icon in header and it`s id', () => {
+    const component = mount(
+      <Provider>
+        <Router>
+          <Header />
+        </Router>
+      </Provider>
+    );
+
+    expect(component.find(Icon).length).toBe(1);
+    expect(component.find(Icon).props().id).toBe(Icons.Help);
   });
 
   it('should render user profile', (done) => {

--- a/ui/src/containers/Header/__snapshots__/Header.test.tsx.snap
+++ b/ui/src/containers/Header/__snapshots__/Header.test.tsx.snap
@@ -19,8 +19,8 @@ exports[`Header should render the header component and find Search component 1`]
               <div className=\\"pf-c-page__header-tools\\">
                 <Grid>
                   <div className=\\"pf-l-grid\\">
-                    <GridItem span={11}>
-                      <div className=\\"pf-l-grid__item pf-m-11-col\\">
+                    <GridItem span={10}>
+                      <div className=\\"pf-l-grid__item pf-m-10-col\\">
                         <Memo(wrappedComponent)>
                           <ForwardRef type=\\"search\\" value=\\"\\" onChange={[Function: onSearchChange]} onKeyPress={[Function: onSearchKeyPress]} aria-label=\\"text input example\\" placeholder=\\"Search for resources...\\" spellCheck=\\"false\\" className=\\"hub-search\\">
                             <TextInputBase type=\\"search\\" value=\\"\\" onChange={[Function: onSearchChange]} onKeyPress={[Function: onSearchKeyPress]} aria-label=\\"text input example\\" placeholder=\\"Search for resources...\\" spellCheck=\\"false\\" className=\\"hub-search\\" innerRef={{...}} isRequired={false} validated=\\"default\\" isDisabled={false} isReadOnly={false} isLeftTruncated={false}>
@@ -28,6 +28,17 @@ exports[`Header should render the header component and find Search component 1`]
                             </TextInputBase>
                           </ForwardRef>
                         </Memo(wrappedComponent)>
+                      </div>
+                    </GridItem>
+                    <GridItem span={1} onClick={[Function: onClick]} className=\\"header-search-hint\\">
+                      <div className=\\"pf-l-grid__item pf-m-1-col header-search-hint\\" onClick={[Function: onClick]}>
+                        <Icon id=\\"help\\" size=\\"sm\\" label=\\"search-tips\\">
+                          <HelpIcon size=\\"sm\\" label=\\"search-tips\\" color=\\"currentColor\\" noVerticalAlign={false}>
+                            <svg style={{...}} fill=\\"currentColor\\" height=\\"1em\\" width=\\"1em\\" viewBox=\\"0 64 1024 1024\\" aria-labelledby={{...}} aria-hidden={true} role=\\"img\\" label=\\"search-tips\\">
+                              <path d=\\"M512.059-73.143c-282.338 0-512.059 229.673-512.059 512.025 0 282.235 229.721 511.975 512.059 511.975 282.281 0 511.941-229.735 511.941-511.975 0.005-282.352-229.659-512.025-511.941-512.025zM512.059 826.523c-213.826 0-387.728-173.856-387.728-387.643 0-213.89 173.904-387.694 387.728-387.694 213.717 0 387.671 173.803 387.671 387.694 0.005 213.785-173.957 387.643-387.671 387.643zM585.143 164.571v109.714c0 4.951-1.808 9.237-5.429 12.857s-7.906 5.429-12.857 5.429h-109.714c-4.953 0-9.239-1.808-12.857-5.429s-5.429-7.906-5.429-12.857v-109.714c0-4.951 1.81-9.237 5.429-12.857s7.904-5.429 12.857-5.429h109.714c4.951 0 9.237 1.808 12.857 5.429s5.429 7.906 5.429 12.857zM521.616 365.714c118.343 0 214.286 88.965 214.286 187.429s-95.943 178.286-214.286 178.286c-173.045 0-208.091-93.714-213.963-171.113 0-7.936 6.729-9.838 15.872-9.838s108.073 0 113.143 0c6.096 0 14.475 0.633 17.554 10.571 0 48.857 135.968 54.953 135.968-7.904 0-31.506-29.717-63.817-68.571-66.194s-82.286-7.607-82.286-54.199c0-13.022 0-25.673 0-44.693 0-19.015 9.717-22.343 27.431-22.343s54.853-0.002 54.853-0.002z\\" transform=\\"rotate(180 0 512) scale(-1 1)\\" />
+                            </svg>
+                          </HelpIcon>
+                        </Icon>
                       </div>
                     </GridItem>
                   </div>
@@ -49,6 +60,11 @@ exports[`Header should render the header component and find Search component 1`]
             </PageHeaderTools>
           </header>
         </PageHeader>
+        <Modal variant=\\"small\\" title=\\"Search tips:\\" isOpen={false} onClose={[Function: onClose]} className=\\"\\" aria-label=\\"\\" showClose={true} aria-describedby=\\"\\" aria-labelledby=\\"\\" id={[undefined]} actions={{...}} hasNoBodyWrapper={false} appendTo={[Function: appendTo]} ouiaSafe={true}>
+          <Portal containerInfo={{...}}>
+            <ModalContent variant=\\"small\\" isOpen={false} onClose={[Function: onClose]} className=\\"\\" showClose={true} id={[undefined]} actions={{...}} hasNoBodyWrapper={false} boxId=\\"pf-modal-part-0\\" labelId=\\"pf-modal-part-1\\" descriptorId=\\"pf-modal-part-2\\" title=\\"Search tips:\\" aria-label=\\"\\" aria-describedby=\\"\\" aria-labelledby=\\"\\" ouiaId={[undefined]} ouiaSafe={true} />
+          </Portal>
+        </Modal>
       </Memo(wrappedComponent)>
     </Router>
   </BrowserRouter>

--- a/ui/src/containers/Header/index.tsx
+++ b/ui/src/containers/Header/index.tsx
@@ -9,24 +9,36 @@ import {
   Text,
   TextVariants,
   GridItem,
-  Grid
+  Grid,
+  Modal,
+  ModalVariant,
+  TextContent,
+  TextList,
+  TextListItem
 } from '@patternfly/react-core';
 import logo from '../../assets/logo/logo.png';
+import { IconSize } from '@patternfly/react-icons';
 import Search from '../../containers/Search';
 import UserProfile from '../UserProfile';
 import { useMst } from '../../store/root';
 import './Header.css';
 import { scrollToTop } from '../../common/scrollToTop';
+import Icon from '../../components/Icon';
+import { Icons } from '../../common/icons';
 
 const Header: React.FC = observer(() => {
   const { user } = useMst();
   const history = useHistory();
+  const [isModalOpen, setIsModalOpen] = React.useState(false);
 
   const headerTools = (
     <PageHeaderTools>
       <Grid>
-        <GridItem span={11}>
+        <GridItem span={10}>
           <Search />
+        </GridItem>
+        <GridItem span={1} onClick={() => setIsModalOpen(true)} className="header-search-hint">
+          <Icon id={Icons.Help} size={IconSize.sm} label={'search-tips'} />
         </GridItem>
       </Grid>
       {user.isAuthenticated && user.refreshTokenInfo.expiresAt * 1000 > global.Date.now() ? (
@@ -52,6 +64,25 @@ const Header: React.FC = observer(() => {
         logo={<Brand src={logo} alt="Tekton Hub Logo" onClick={homePage} />}
         headerTools={headerTools}
       />
+      <Modal
+        variant={ModalVariant.small}
+        title="Search tips:"
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+      >
+        <Grid>
+          <TextContent>
+            <TextList>
+              <TextListItem>Press `/` to quick focus on search</TextListItem>
+              <TextListItem>Search resources by it&#39;s name, displayName and tags</TextListItem>
+              <TextListItem>
+                Filter resources by tags with searching tags in a specific format e.g.
+                `tags:tagA,tagB`
+              </TextListItem>
+            </TextList>
+          </TextContent>
+        </Grid>
+      </Modal>
     </React.Fragment>
   );
 });


### PR DESCRIPTION
# Changes

This patch add a help icon to the right of search box,
onclick event it opens a modal which contains few search tips
that would help to users for better resource search


![Screenshot from 2021-07-27 19-27-15](https://user-images.githubusercontent.com/31416465/127166868-fdf57d11-9c8e-4179-a3c7-93405af671fb.png)



    
Signed-off-by: Shiv Verma <shverma@redhat.com>

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._

