### PR TITLE
Updates the Catalog Sync to handle Categories if not present in Hub

### DIFF
--- a/api/pkg/parser/catalog.go
+++ b/api/pkg/parser/catalog.go
@@ -277,6 +277,9 @@ func (c CatalogParser) appendVersion(res *Resource, filePath string) Result {
 
 	categories := annotations[CategoryAnnotation]
 	categoryList := strings.FieldsFunc(categories, func(c rune) bool { return c == ',' })
+	for c := range categoryList {
+		categoryList[c] = strings.TrimSpace(categoryList[c])
+	}
 	res.Categories = append(res.Categories, categoryList...)
 
 	res.Versions = append(res.Versions,


### PR DESCRIPTION
  - Initially if there are categories in task which are not
    present in Hub, that categories used to get added in
    Hub db, this patch handles it by adding a record in
    Catalog_Errors table and not adding the categories in DB

Signed-off-by: Puneet Punamiya <ppunamiy@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._

