### PR TITLE
WIP: Restructure the API codebase

### DIFF
--- a/api/.env.dev
+++ b/api/.env.dev
@@ -6,12 +6,13 @@ POSTGRES_DB="hub"
 POSTGRES_USER="postgres"
 POSTGRES_PASSWORD="postgres"
 
-GH_CLIENT_ID="client-id"
-GH_CLIENT_SECRET="client-secret"
+CLIENT_ID="client-id"
+CLIENT_SECRET="client-secret"
 
 JWT_SIGNING_KEY="TektonHub"
 ACCESS_JWT_EXPIRES_IN="1s"
 REFRESH_JWT_EXPIRES_IN="1s"
-GHE_URL=""
+ENTERPRISE_URL=""
+GIT_PROVIDER=""
 
 CONFIG_FILE_URL="file://../config.yaml"

--- a/api/pkg/db/initializer/initializer.go
+++ b/api/pkg/db/initializer/initializer.go
@@ -127,7 +127,7 @@ func addUsers(db *gorm.DB, log *log.Logger, data *app.Data) error {
 		for _, userID := range s.Users {
 
 			// Checks if user exists
-			q := db.Where("LOWER(github_login) = ?", strings.ToLower(userID))
+			q := db.Where("LOWER(git_username) = ?", strings.ToLower(userID))
 
 			user := model.User{}
 			if err := q.First(&user).Error; err != nil {
@@ -138,7 +138,7 @@ func addUsers(db *gorm.DB, log *log.Logger, data *app.Data) error {
 				}
 
 				log.Infof("user %s not found, create a new user", userID)
-				user.GithubLogin = strings.ToLower(userID)
+				user.GitUsername = strings.ToLower(userID)
 				if err = db.Create(&user).Error; err != nil {
 					log.Error(err)
 					return err

--- a/api/pkg/db/migration/202107091127_rename_githubname__to_name_and_githublogin_to_git_username.go
+++ b/api/pkg/db/migration/202107091127_rename_githubname__to_name_and_githublogin_to_git_username.go
@@ -1,0 +1,40 @@
+// Copyright © 2021 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migration
+
+import (
+	"github.com/go-gormigrate/gormigrate/v2"
+	"github.com/tektoncd/hub/api/gen/log"
+	"github.com/tektoncd/hub/api/pkg/db/model"
+	"gorm.io/gorm"
+)
+
+func renameGithubNameAndGithubLoginToNameAndGitUsername(log *log.Logger) *gormigrate.Migration {
+
+	return &gormigrate.Migration{
+		ID: "202107091127_rename_githubname__to_name_and_githublogin_to_git_username",
+		Migrate: func(db *gorm.DB) error {
+			if err := db.Migrator().RenameColumn(&model.User{}, "github_login", "git_username"); err != nil {
+				log.Error(err)
+				return err
+			}
+
+			if err := db.Migrator().RenameColumn(&model.User{}, "github_name", "name"); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+}

--- a/api/pkg/db/migration/migration.go
+++ b/api/pkg/db/migration/migration.go
@@ -38,6 +38,7 @@ func Migrate(api *app.APIBase) error {
 			addAvatarURLColumnInUsersTable(log),
 			removeCatgoryIdColumnAndConstraintsFromTagtable(log),
 			updateResourcesCategoryTable(log),
+			renameGithubNameAndGithubLoginToNameAndGitUsername(log),
 		},
 	)
 

--- a/api/pkg/db/model/model.go
+++ b/api/pkg/db/model/model.go
@@ -91,8 +91,8 @@ type (
 	User struct {
 		gorm.Model
 		AgentName            string
-		GithubLogin          string
-		GithubName           string
+		GitUsername          string
+		Name                 string
 		Type                 UserType
 		Scopes               []*Scope `gorm:"many2many:user_scopes;"`
 		RefreshTokenChecksum string

--- a/api/pkg/service/admin/admin.go
+++ b/api/pkg/service/admin/admin.go
@@ -191,7 +191,7 @@ func (r *agentRequest) addScopesForAgent(agent *model.User, scopes []string) err
 func (r *agentRequest) userExistWithAgentName(name string) error {
 
 	user := model.User{}
-	q := r.db.Where("LOWER(github_name) = ?", strings.ToLower(name))
+	q := r.db.Where("LOWER(name) = ?", strings.ToLower(name))
 
 	if err := q.First(&user).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {

--- a/api/pkg/service/admin/admin_http_test.go
+++ b/api/pkg/service/admin/admin_http_test.go
@@ -49,7 +49,7 @@ func TestUpdateAgent_Http_NewAgent(t *testing.T) {
 
 	// user with agent:create scope
 	user, accessToken, err := tc.UserWithScopes("foo", "agent:create")
-	assert.Equal(t, user.GithubLogin, "foo")
+	assert.Equal(t, user.GitUsername, "foo")
 	assert.NoError(t, err)
 
 	// Mocks the time
@@ -85,7 +85,7 @@ func TestUpdateAgent_Http_NormalUserExistWithName(t *testing.T) {
 
 	// user with agent:create scope
 	user, accessToken, err := tc.UserWithScopes("foo", "agent:create")
-	assert.Equal(t, user.GithubLogin, "foo")
+	assert.Equal(t, user.GitUsername, "foo")
 	assert.NoError(t, err)
 
 	// Mocks the time
@@ -115,7 +115,7 @@ func TestUpdateAgent_Http_InvalidScopeCase(t *testing.T) {
 
 	// user with agent:create scope
 	user, accessToken, err := tc.UserWithScopes("foo", "agent:create")
-	assert.Equal(t, user.GithubLogin, "foo")
+	assert.Equal(t, user.GitUsername, "foo")
 	assert.NoError(t, err)
 
 	// Mocks the time
@@ -145,7 +145,7 @@ func TestUpdateAgent_Http_UpdateCase(t *testing.T) {
 
 	// user with agent:create scope
 	user, accessToken, err := tc.UserWithScopes("foo", "agent:create")
-	assert.Equal(t, user.GithubLogin, "foo")
+	assert.Equal(t, user.GitUsername, "foo")
 	assert.NoError(t, err)
 
 	// Mocks the time
@@ -189,7 +189,7 @@ func TestRefreshConfig_Http(t *testing.T) {
 
 	// user with config:refresh scope
 	user, token, err := tc.UserWithScopes("foo", "config:refresh")
-	assert.Equal(t, user.GithubLogin, "foo")
+	assert.Equal(t, user.GitUsername, "foo")
 	assert.NoError(t, err)
 
 	// Mocks the time
@@ -222,7 +222,7 @@ func TestRefreshConfig_Http(t *testing.T) {
 		err = tc.DB().Where(&scope).First(&scope).Error
 		assert.NoError(t, err)
 
-		user := model.User{GithubLogin: "test-user"}
+		user := model.User{GitUsername: "test-user"}
 		err = tc.DB().Where(&user).First(&user).Error
 		assert.NoError(t, err)
 	})

--- a/api/pkg/service/admin/admin_test.go
+++ b/api/pkg/service/admin/admin_test.go
@@ -31,7 +31,7 @@ func TestUpdateAgent(t *testing.T) {
 
 	// user with agent:create scope
 	user, _, err := tc.UserWithScopes("foo", "agent:create")
-	assert.Equal(t, user.GithubLogin, "foo")
+	assert.Equal(t, user.GitUsername, "foo")
 	assert.NoError(t, err)
 
 	// Mocks the time
@@ -57,7 +57,7 @@ func TestUpdateAgent_NormalUserExistsWithName(t *testing.T) {
 
 	// user with agent:create scope
 	user, _, err := tc.UserWithScopes("foo", "agent:create")
-	assert.Equal(t, user.GithubLogin, "foo")
+	assert.Equal(t, user.GitUsername, "foo")
 	assert.NoError(t, err)
 
 	adminSvc := New(tc)
@@ -74,7 +74,7 @@ func TestUpdateAgent_InvalidScopeInPayload(t *testing.T) {
 
 	// user with agent:create scope
 	user, _, err := tc.UserWithScopes("foo", "agent:create")
-	assert.Equal(t, user.GithubLogin, "foo")
+	assert.Equal(t, user.GitUsername, "foo")
 	assert.NoError(t, err)
 
 	adminSvc := New(tc)
@@ -91,7 +91,7 @@ func TestUpdateAgent_UpdateScopesCase(t *testing.T) {
 
 	// user with agent:create scope
 	user, _, err := tc.UserWithScopes("foo", "agent:create")
-	assert.Equal(t, user.GithubLogin, "foo")
+	assert.Equal(t, user.GitUsername, "foo")
 	assert.NoError(t, err)
 
 	// Mocks the time

--- a/api/pkg/service/auth/auth_http_test.go
+++ b/api/pkg/service/auth/auth_http_test.go
@@ -81,12 +81,12 @@ func TestLogin_Http(t *testing.T) {
 
 		// expected access jwt for user
 		user, accessToken, err := tc.UserWithScopes("test", "rating:read", "rating:write")
-		assert.Equal(t, user.GithubLogin, "test")
+		assert.Equal(t, user.GitUsername, "test")
 		assert.NoError(t, err)
 
 		// expected refresh jwt for user
 		user, refreshToken, err := tc.RefreshTokenForUser("test")
-		assert.Equal(t, user.GithubLogin, "test")
+		assert.Equal(t, user.GitUsername, "test")
 		assert.NoError(t, err)
 
 		assert.Equal(t, accessToken, res.Data.Access.Token)
@@ -170,12 +170,12 @@ func TestLogin_Http_UserWithExtraScope(t *testing.T) {
 
 		// expected access jwt for user
 		user, accessToken, err := tc.UserWithScopes("foo", "rating:read", "rating:write", "agent:create")
-		assert.Equal(t, user.GithubLogin, "foo")
+		assert.Equal(t, user.GitUsername, "foo")
 		assert.NoError(t, err)
 
 		// expected refresh jwt for user
 		user, refreshToken, err := tc.RefreshTokenForUser("foo")
-		assert.Equal(t, user.GithubLogin, "foo")
+		assert.Equal(t, user.GitUsername, "foo")
 		assert.NoError(t, err)
 
 		assert.Equal(t, accessToken, res.Data.Access.Token)

--- a/api/pkg/service/auth/auth_test.go
+++ b/api/pkg/service/auth/auth_test.go
@@ -58,12 +58,12 @@ func TestLogin(t *testing.T) {
 
 	// expected access jwt for user
 	user, accessToken, err := tc.UserWithScopes("test", "rating:read", "rating:write")
-	assert.Equal(t, user.GithubLogin, "test")
+	assert.Equal(t, user.GitUsername, "test")
 	assert.NoError(t, err)
 
 	// expected refresh jwt for user
 	user, refreshToken, err := tc.RefreshTokenForUser("test")
-	assert.Equal(t, user.GithubLogin, "test")
+	assert.Equal(t, user.GitUsername, "test")
 	assert.NoError(t, err)
 
 	accessExpiryTime := testutils.Now().Add(tc.JWTConfig().AccessExpiresIn).Unix()
@@ -112,12 +112,12 @@ func TestLogin_again(t *testing.T) {
 
 	// expected access jwt for user
 	user, accessToken, err := tc.UserWithScopes("test", "rating:read", "rating:write")
-	assert.Equal(t, user.GithubLogin, "test")
+	assert.Equal(t, user.GitUsername, "test")
 	assert.NoError(t, err)
 
 	// expected refresh jwt for user
 	user, refreshToken, err := tc.RefreshTokenForUser("test")
-	assert.Equal(t, user.GithubLogin, "test")
+	assert.Equal(t, user.GitUsername, "test")
 	assert.NoError(t, err)
 
 	assert.Equal(t, accessToken, res.Data.Access.Token)
@@ -183,7 +183,7 @@ func TestLogin_UserWithExtraScope(t *testing.T) {
 
 	// foo user is fetched from db to check its existing token checksum
 	user, _, err := tc.UserWithScopes("foo")
-	assert.Equal(t, user.GithubLogin, "foo")
+	assert.Equal(t, user.GitUsername, "foo")
 	assert.NoError(t, err)
 
 	// validate existing checksum
@@ -199,12 +199,12 @@ func TestLogin_UserWithExtraScope(t *testing.T) {
 
 	// expected access jwt for user
 	user, accessToken, err := tc.UserWithScopes("foo", "rating:read", "rating:write", "agent:create")
-	assert.Equal(t, user.GithubLogin, "foo")
+	assert.Equal(t, user.GitUsername, "foo")
 	assert.NoError(t, err)
 
 	// expected refresh jwt for user
 	user, refreshToken, err := tc.RefreshTokenForUser("foo")
-	assert.Equal(t, user.GithubLogin, "foo")
+	assert.Equal(t, user.GitUsername, "foo")
 	assert.NoError(t, err)
 
 	assert.Equal(t, accessToken, res.Data.Access.Token)
@@ -250,7 +250,7 @@ func TestLogin_UserAddedByConfig(t *testing.T) {
 
 	// expected access jwt for user
 	user, accessToken, err := tc.UserWithScopes("config-user", "rating:read", "rating:write", "config:refresh")
-	assert.Equal(t, user.GithubLogin, "config-user")
+	assert.Equal(t, user.GitUsername, "config-user")
 	assert.NoError(t, err)
 
 	// validate the avatar_url of user after login
@@ -261,7 +261,7 @@ func TestLogin_UserAddedByConfig(t *testing.T) {
 
 	// expected refresh jwt for user
 	user, refreshToken, err := tc.RefreshTokenForUser("config-user")
-	assert.Equal(t, user.GithubLogin, "config-user")
+	assert.Equal(t, user.GitUsername, "config-user")
 	assert.NoError(t, err)
 
 	accessExpiryTime := testutils.Now().Add(tc.JWTConfig().AccessExpiresIn).Unix()

--- a/api/pkg/service/catalog/catalog_test.go
+++ b/api/pkg/service/catalog/catalog_test.go
@@ -43,7 +43,7 @@ func TestRefresh(t *testing.T) {
 
 	// user with catalog:refresh scope
 	user, _, err := tc.UserWithScopes("foo", "catalog:refresh")
-	assert.Equal(t, user.GithubLogin, "foo")
+	assert.Equal(t, user.GitUsername, "foo")
 	assert.NoError(t, err)
 
 	catalogSvc := NewServiceTest(tc)
@@ -62,7 +62,7 @@ func TestRefresh_CatalogNotFound(t *testing.T) {
 
 	// user with catalog:refresh scope
 	user, _, err := tc.UserWithScopes("foo", "catalog:refresh")
-	assert.Equal(t, user.GithubLogin, "foo")
+	assert.Equal(t, user.GitUsername, "foo")
 	assert.NoError(t, err)
 
 	catalogSvc := NewServiceTest(tc)
@@ -80,7 +80,7 @@ func TestRefreshAgain(t *testing.T) {
 
 	// user with catalog:refresh scopes
 	user, _, err := tc.UserWithScopes("foo", "catalog:refresh")
-	assert.Equal(t, user.GithubLogin, "foo")
+	assert.Equal(t, user.GitUsername, "foo")
 	assert.NoError(t, err)
 
 	catalogSvc := NewServiceTest(tc)
@@ -104,7 +104,7 @@ func TestRefresh_All(t *testing.T) {
 
 	// user with catalog:refresh scope
 	user, _, err := tc.UserWithScopes("foo", "catalog:refresh")
-	assert.Equal(t, user.GithubLogin, "foo")
+	assert.Equal(t, user.GitUsername, "foo")
 	assert.NoError(t, err)
 
 	catalogSvc := NewServiceTest(tc)
@@ -129,7 +129,7 @@ func TestCatalogError(t *testing.T) {
 
 	// User with catalog:refresh scope
 	user, _, err := tc.UserWithScopes("foo", "catalog:refresh")
-	assert.Equal(t, user.GithubLogin, "foo")
+	assert.Equal(t, user.GitUsername, "foo")
 	assert.NoError(t, err)
 
 	catalogSvc := NewServiceTest(tc)
@@ -150,7 +150,7 @@ func TestCatalogErrorHavingNoError(t *testing.T) {
 
 	// User with catalog:refresh scope
 	user, _, err := tc.UserWithScopes("foo", "catalog:refresh")
-	assert.Equal(t, user.GithubLogin, "foo")
+	assert.Equal(t, user.GitUsername, "foo")
 	assert.NoError(t, err)
 
 	catalogSvc := NewServiceTest(tc)

--- a/api/pkg/service/rating/rating_http_test.go
+++ b/api/pkg/service/rating/rating_http_test.go
@@ -65,7 +65,7 @@ func TestGet_Http_ExpiredToken(t *testing.T) {
 
 	// user with rating:read scope
 	user, accessToken, err := tc.UserWithScopes("foo", "rating:read")
-	assert.Equal(t, user.GithubLogin, "foo")
+	assert.Equal(t, user.GitUsername, "foo")
 	assert.NoError(t, err)
 
 	// Mocks the time
@@ -93,7 +93,7 @@ func TestGet_Http_InvalidScopes(t *testing.T) {
 
 	// invalid user access token, does not have required scopes
 	user, accessToken, err := tc.UserWithScopes("abc", "catalog:refresh")
-	assert.Equal(t, user.GithubLogin, "abc")
+	assert.Equal(t, user.GitUsername, "abc")
 	assert.NoError(t, err)
 
 	// Mocks the time
@@ -120,7 +120,7 @@ func TestGet_Http(t *testing.T) {
 
 	// user with rating:read scope
 	user, accessToken, err := tc.UserWithScopes("foo", "rating:read")
-	assert.Equal(t, user.GithubLogin, "foo")
+	assert.Equal(t, user.GitUsername, "foo")
 	assert.NoError(t, err)
 
 	// Mocks the time
@@ -147,7 +147,7 @@ func TestGet_Http_RatingNotFound(t *testing.T) {
 
 	// user with rating:read scope
 	user, accessToken, err := tc.UserWithScopes("foo", "rating:read")
-	assert.Equal(t, user.GithubLogin, "foo")
+	assert.Equal(t, user.GitUsername, "foo")
 	assert.NoError(t, err)
 
 	// Mocks the time
@@ -174,7 +174,7 @@ func TestGet_Http_ResourceNotFound(t *testing.T) {
 
 	// user with rating:read scope
 	user, accessToken, err := tc.UserWithScopes("foo", "rating:read")
-	assert.Equal(t, user.GithubLogin, "foo")
+	assert.Equal(t, user.GitUsername, "foo")
 	assert.NoError(t, err)
 
 	// Mocks the time
@@ -210,7 +210,7 @@ func TestUpdate_Http(t *testing.T) {
 
 	// user with rating:write scope
 	user, accessToken, err := tc.UserWithScopes("foo", "rating:write")
-	assert.Equal(t, user.GithubLogin, "foo")
+	assert.Equal(t, user.GitUsername, "foo")
 	assert.NoError(t, err)
 
 	// Mocks the time
@@ -236,7 +236,7 @@ func TestUpdate_Http_Existing(t *testing.T) {
 
 	// user with rating:write scope
 	user, accessToken, err := tc.UserWithScopes("foo", "rating:write")
-	assert.Equal(t, user.GithubLogin, "foo")
+	assert.Equal(t, user.GitUsername, "foo")
 	assert.NoError(t, err)
 
 	// Mocks the time
@@ -262,7 +262,7 @@ func TestUpdate_Http_ResourceNotFound(t *testing.T) {
 
 	// user with rating:write scope
 	user, accessToken, err := tc.UserWithScopes("foo", "rating:write")
-	assert.Equal(t, user.GithubLogin, "foo")
+	assert.Equal(t, user.GitUsername, "foo")
 	assert.NoError(t, err)
 
 	// Mocks the time

--- a/api/pkg/service/rating/rating_test.go
+++ b/api/pkg/service/rating/rating_test.go
@@ -30,7 +30,7 @@ func TestGet(t *testing.T) {
 
 	// user with rating:read scope
 	user, _, err := tc.UserWithScopes("foo", "rating:read")
-	assert.Equal(t, user.GithubLogin, "foo")
+	assert.Equal(t, user.GitUsername, "foo")
 	assert.NoError(t, err)
 
 	ratingSvc := New(tc)
@@ -47,7 +47,7 @@ func TestGet_RatingNotFound(t *testing.T) {
 
 	// user with rating:read scope
 	user, _, err := tc.UserWithScopes("foo", "rating:read")
-	assert.Equal(t, user.GithubLogin, "foo")
+	assert.Equal(t, user.GitUsername, "foo")
 	assert.NoError(t, err)
 
 	ratingSvc := New(tc)
@@ -64,7 +64,7 @@ func TestGet_ResourceNotFound(t *testing.T) {
 
 	// user with rating:read scope
 	user, _, err := tc.UserWithScopes("foo", "rating:read")
-	assert.Equal(t, user.GithubLogin, "foo")
+	assert.Equal(t, user.GitUsername, "foo")
 	assert.NoError(t, err)
 
 	ratingSvc := New(tc)
@@ -81,7 +81,7 @@ func TestUpdate(t *testing.T) {
 
 	// user with rating:write scope
 	user, _, err := tc.UserWithScopes("foo", "rating:write")
-	assert.Equal(t, user.GithubLogin, "foo")
+	assert.Equal(t, user.GitUsername, "foo")
 	assert.NoError(t, err)
 
 	ratingSvc := New(tc)
@@ -97,7 +97,7 @@ func TestUpdate_ResourceNotFound(t *testing.T) {
 
 	// user with rating:write scope
 	user, _, err := tc.UserWithScopes("foo", "rating:write")
-	assert.Equal(t, user.GithubLogin, "foo")
+	assert.Equal(t, user.GitUsername, "foo")
 	assert.NoError(t, err)
 
 	ratingSvc := New(tc)

--- a/api/pkg/service/user/user.go
+++ b/api/pkg/service/user/user.go
@@ -121,7 +121,7 @@ func (r *request) userScopes() ([]string, error) {
 
 	var userScopes []string = r.defaultScopes
 
-	q := r.db.Preload("Scopes").Where(&model.User{GithubLogin: r.user.GithubLogin})
+	q := r.db.Preload("Scopes").Where(&model.User{GitUsername: r.user.GitUsername})
 
 	dbUser := &model.User{}
 	if err := q.Find(dbUser).Error; err != nil {
@@ -190,8 +190,8 @@ func (s *service) Info(ctx context.Context, p *user.InfoPayload) (*user.InfoResu
 		return nil, err
 	}
 	res := &user.InfoResult{Data: &user.UserData{
-		GithubID:  data.GithubLogin,
-		Name:      data.GithubName,
+		GithubID:  data.GitUsername,
+		Name:      data.Name,
 		AvatarURL: data.AvatarURL,
 	},
 	}

--- a/api/pkg/service/user/user_http_test.go
+++ b/api/pkg/service/user/user_http_test.go
@@ -46,7 +46,7 @@ func TestRefreshAccessToken_Http(t *testing.T) {
 
 	// user refresh token
 	testUser, refreshToken, err := tc.RefreshTokenForUser("abc")
-	assert.Equal(t, testUser.GithubLogin, "abc")
+	assert.Equal(t, testUser.GitUsername, "abc")
 	assert.NoError(t, err)
 
 	// Mocks the time
@@ -66,7 +66,7 @@ func TestRefreshAccessToken_Http(t *testing.T) {
 
 		// expected access jwt
 		user, accessToken, err := tc.UserWithScopes("abc", "rating:read", "rating:write")
-		assert.Equal(t, user.GithubName, "abc")
+		assert.Equal(t, user.Name, "abc")
 		assert.NoError(t, err)
 
 		assert.Equal(t, accessToken, res.Data.Access.Token)
@@ -79,7 +79,7 @@ func TestRefreshAccessToken_Http_ExpiredRefreshToken(t *testing.T) {
 
 	// user refresh token
 	testUser, refreshToken, err := tc.RefreshTokenForUser("abc")
-	assert.Equal(t, testUser.GithubLogin, "abc")
+	assert.Equal(t, testUser.GitUsername, "abc")
 	assert.NoError(t, err)
 
 	// Mocks the time
@@ -105,7 +105,7 @@ func TestRefreshAccessToken_Http_RefreshTokenChecksumIsDifferent(t *testing.T) {
 
 	// user refresh token
 	testUser, refreshToken, err := tc.RefreshTokenForUser("foo")
-	assert.Equal(t, testUser.GithubLogin, "foo")
+	assert.Equal(t, testUser.GitUsername, "foo")
 	assert.NoError(t, err)
 
 	// Mocks the time
@@ -140,7 +140,7 @@ func TestNewRefreshToken_Http(t *testing.T) {
 
 	// user refresh token
 	testUser, refreshToken, err := tc.RefreshTokenForUser("abc")
-	assert.Equal(t, testUser.GithubLogin, "abc")
+	assert.Equal(t, testUser.GitUsername, "abc")
 	assert.NoError(t, err)
 
 	// Mocks the time
@@ -160,7 +160,7 @@ func TestNewRefreshToken_Http(t *testing.T) {
 
 		// user refresh token
 		testUser, refreshToken, err := tc.RefreshTokenForUser("abc")
-		assert.Equal(t, testUser.GithubLogin, "abc")
+		assert.Equal(t, testUser.GitUsername, "abc")
 		assert.NoError(t, err)
 
 		refreshExpiryTime := testutils.Now().Add(tc.JWTConfig().RefreshExpiresIn).Unix()
@@ -177,7 +177,7 @@ func TestNewRefreshToken_Http_RefreshTokenChecksumIsDifferent(t *testing.T) {
 
 	// user refresh token
 	testUser, refreshToken, err := tc.RefreshTokenForUser("foo")
-	assert.Equal(t, testUser.GithubLogin, "foo")
+	assert.Equal(t, testUser.GitUsername, "foo")
 	assert.NoError(t, err)
 
 	// Mocks the time
@@ -211,7 +211,7 @@ func TestUserInfo_Http(t *testing.T) {
 
 	// user refresh token
 	testUser, accessToken, err := tc.UserWithScopes("abc", "rating:read")
-	assert.Equal(t, testUser.GithubLogin, "abc")
+	assert.Equal(t, testUser.GitUsername, "abc")
 	assert.NoError(t, err)
 
 	// Mocks the time

--- a/api/pkg/service/user/user_test.go
+++ b/api/pkg/service/user/user_test.go
@@ -31,7 +31,7 @@ func TestRefreshAccessToken(t *testing.T) {
 
 	// user refresh token
 	testUser, refreshToken, err := tc.RefreshTokenForUser("abc")
-	assert.Equal(t, testUser.GithubLogin, "abc")
+	assert.Equal(t, testUser.GitUsername, "abc")
 	assert.NoError(t, err)
 
 	// Mocks the time
@@ -45,7 +45,7 @@ func TestRefreshAccessToken(t *testing.T) {
 
 	// expected access jwt for user
 	user, accessToken, err := tc.UserWithScopes("abc", "rating:read", "rating:write")
-	assert.Equal(t, user.GithubLogin, "abc")
+	assert.Equal(t, user.GitUsername, "abc")
 	assert.NoError(t, err)
 
 	accessExpiryTime := testutils.Now().Add(tc.JWTConfig().AccessExpiresIn).Unix()
@@ -61,7 +61,7 @@ func TestRefreshAccessToken_RefreshTokenChecksumIsDifferent(t *testing.T) {
 
 	// user refresh token
 	testUser, refreshToken, err := tc.RefreshTokenForUser("foo")
-	assert.Equal(t, testUser.GithubLogin, "foo")
+	assert.Equal(t, testUser.GitUsername, "foo")
 	assert.NoError(t, err)
 
 	userSvc := New(tc)
@@ -78,7 +78,7 @@ func TestNewRefreshToken(t *testing.T) {
 
 	// user refresh token
 	testUser, refreshToken, err := tc.RefreshTokenForUser("abc")
-	assert.Equal(t, testUser.GithubLogin, "abc")
+	assert.Equal(t, testUser.GitUsername, "abc")
 	assert.NoError(t, err)
 
 	// Mocks the time
@@ -92,7 +92,7 @@ func TestNewRefreshToken(t *testing.T) {
 
 	// user refresh token
 	testUser, refreshToken, err = tc.RefreshTokenForUser("abc")
-	assert.Equal(t, testUser.GithubLogin, "abc")
+	assert.Equal(t, testUser.GitUsername, "abc")
 	assert.NoError(t, err)
 
 	refreshExpiryTime := testutils.Now().Add(tc.JWTConfig().RefreshExpiresIn).Unix()
@@ -108,7 +108,7 @@ func TestNewRefreshToken_RefreshTokenChecksumIsDifferent(t *testing.T) {
 
 	// user refresh token
 	testUser, refreshToken, err := tc.RefreshTokenForUser("foo")
-	assert.Equal(t, testUser.GithubLogin, "foo")
+	assert.Equal(t, testUser.GitUsername, "foo")
 	assert.NoError(t, err)
 
 	userSvc := New(tc)
@@ -125,7 +125,7 @@ func TestInfo(t *testing.T) {
 
 	// user Access Token
 	testUser, accessToken, err := tc.UserWithScopes("abc", "rating:read", "rating:write")
-	assert.Equal(t, testUser.GithubLogin, "abc")
+	assert.Equal(t, testUser.GitUsername, "abc")
 	assert.NoError(t, err)
 
 	userSvc := New(tc)

--- a/api/pkg/testutils/utils.go
+++ b/api/pkg/testutils/utils.go
@@ -49,8 +49,8 @@ func FormatJSON(b []byte) (string, error) {
 // User will have same github login and github name in db
 func (tc *TestConfig) UserWithScopes(name string, scopes ...string) (*model.User, string, error) {
 
-	user := &model.User{GithubLogin: name, GithubName: name, Type: model.NormalUserType}
-	if err := tc.DB().Where(&model.User{GithubLogin: name}).
+	user := &model.User{GitUsername: name, Name: name, Type: model.NormalUserType}
+	if err := tc.DB().Where(&model.User{GitUsername: name}).
 		FirstOrCreate(user).Error; err != nil {
 		return nil, "", err
 	}
@@ -74,8 +74,8 @@ func (tc *TestConfig) UserWithScopes(name string, scopes ...string) (*model.User
 // User will have same github login and github name in db
 func (tc *TestConfig) RefreshTokenForUser(name string) (*model.User, string, error) {
 
-	user := &model.User{GithubLogin: name, GithubName: name, Type: model.NormalUserType}
-	if err := tc.DB().Where(&model.User{GithubLogin: name}).
+	user := &model.User{GitUsername: name, Name: name, Type: model.NormalUserType}
+	if err := tc.DB().Where(&model.User{GitUsername: name}).
 		FirstOrCreate(user).Error; err != nil {
 		return nil, "", err
 	}

--- a/api/test/config/env.test
+++ b/api/test/config/env.test
@@ -6,8 +6,10 @@ POSTGRES_DB="hub_test"
 POSTGRES_USER="postgres"
 POSTGRES_PASSWORD="postgres"
 
-GH_CLIENT_ID="test-client-id"
-GH_CLIENT_SECRET="test-client-secret"
+CLIENT_ID="test-client-id"
+CLIENT_SECRET="test-client-secret"
+ENTERPRISE_URL=""
+GIT_PROVIDER=""
 
 JWT_SIGNING_KEY="TeKtOnHuB"
 ACCESS_JWT_EXPIRES_IN="5m"

--- a/api/test/fixtures/users.yaml
+++ b/api/test/fixtures/users.yaml
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 - id: 11
-  github_name: foo
-  github_login: foo
+  name: foo
+  git_username: foo
   avatar_url: 'https://foo'
   type: user
   refresh_token_checksum: test-checksum
@@ -22,8 +22,8 @@
   updated_at: 2016-01-01 12:30:12 UTC
 
 - id: 13
-  github_name: abc
-  github_login: abc
+  name: abc
+  git_username: abc
   avatar_url: 'https://bar'
   type: user
   refresh_token_checksum: 7bd024c1d9a3009dd4208891f2ffd49cb5e972c034bce46883a7c1d982ba9b39
@@ -37,7 +37,7 @@
   updated_at: 2016-01-01 12:30:12 UTC
 
 - id: 31
-  github_login: config-user
+  git_username: config-user
   avatar_url: ''
   created_at: 2016-01-01 12:30:12 UTC
   updated_at: 2016-01-01 12:30:12 UTC


### PR DESCRIPTION
# Changes

Refractor auth code so that it becomes easy to add other oauth support provided by different git providers such as gitlab, bitbucket etc

- Rename `GH_CLIENT_ID` => `CLIENT_ID` and similarly `GH_CLIENT_SECRET` => `CLIENT_SECRET`
- Rename `GHE_URL` => `ENTERPRISE_URL` and add one more env `GIT_PROVIDER` which will hold the value such as `gitlab`, `bitbucket` etc and if empty will default to `github`
- Rename `GithubLogin` to `GitUsername` and `GithubName` to `Name` in `user` model and add `db-migration` for the same.


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Run API Unit Tests, Lint Checks, API Design, Golden Files with `make api-check`
- [ ] Run UI Unit Tests, Lint Checks with `make ui-check`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._
