### PR TITLE
Adds a migration to remove existing Categories

### DIFF
--- a/api/pkg/db/migration/202107131802_remove_existing_categories.go
+++ b/api/pkg/db/migration/202107131802_remove_existing_categories.go
@@ -1,0 +1,38 @@
+// Copyright © 2021 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migration
+
+import (
+	"github.com/go-gormigrate/gormigrate/v2"
+	"github.com/tektoncd/hub/api/gen/log"
+	"github.com/tektoncd/hub/api/pkg/db/model"
+	"gorm.io/gorm"
+)
+
+// Removes Existing Categories which are not present
+// in pre-defined Category List
+func removeExistingCategories(log *log.Logger) *gormigrate.Migration {
+
+	return &gormigrate.Migration{
+		ID: "202107131802_remove_existing_categories",
+		Migrate: func(db *gorm.DB) error {
+			if err := db.Unscoped().Where("name IN ?", []string{"Deploy", "Editor", "Language", "Notification", "Others", "Test Framework"}).Delete(&model.Category{}).Error; err != nil {
+				log.Error(err)
+				return err
+			}
+			return nil
+		},
+	}
+}

--- a/api/pkg/db/migration/migration.go
+++ b/api/pkg/db/migration/migration.go
@@ -38,6 +38,7 @@ func Migrate(api *app.APIBase) error {
 			addAvatarURLColumnInUsersTable(log),
 			removeCatgoryIdColumnAndConstraintsFromTagtable(log),
 			updateResourcesCategoryTable(log),
+			removeExistingCategories(log),
 		},
 	)
 


### PR DESCRIPTION
Initially there were some categories in the config.yaml which are not 
part of the predefined category list and thus the existing categories 
were still present in the db, for example there was one category
named `Deploy` which in predefined category list is changed to `Deployment`, 
hence in order to keep the list generalized and have proper resource category
mapping and show only the predefined generalized categories on UI, this patch 
adds a migration to remove this existing categories 

Signed-off-by: Puneet Punamiya <ppunamiy@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Run API Unit Tests, Lint Checks, API Design, Golden Files with `make api-check`
- [ ] Run UI Unit Tests, Lint Checks with `make ui-check`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._
