### PR TITLE
CLI: Updates `tkn hub info task` cli command for --version flag to include deprecation info

### DIFF
--- a/api/pkg/cli/cmd/info/info.go
+++ b/api/pkg/cli/cmd/info/info.go
@@ -43,7 +43,7 @@ const resTemplate = `{{ icon "name" }}Name: {{ .Resource.Name }}
 {{ $n := .ResVersion.DisplayName }}{{ if ne (default $n "") "" }}
 {{ icon "displayName" }}Display Name: {{ $n }}
 {{ end }}
-{{ icon "version" }}Version: {{ formatVersion .ResVersion.Version .Latest }}
+{{ icon "version" }}Version: {{ formatVersion .ResVersion.Version .Latest .Deprecated }}
 
 {{ icon "description" }}Description: {{ formatDesc .ResVersion.Description 80 16 }}
 
@@ -78,6 +78,7 @@ type templateData struct {
 	Resource   *hub.ResourceData
 	ResVersion *hub.ResourceWithVersionData
 	Latest     bool
+	Deprecated bool
 }
 
 type options struct {
@@ -194,11 +195,19 @@ func (opts *options) run() error {
 	out := opts.cli.Stream().Out
 
 	resVersion := resource.(hub.ResourceWithVersionData)
+
+	var deprecated bool
+	if resVersion.Deprecated != nil {
+		deprecated = true
+	}
+
 	tmplData := templateData{
 		ResVersion: &resVersion,
 		Resource:   resVersion.Resource,
 		Latest:     false,
+		Deprecated: deprecated,
 	}
+
 	return printer.New(out).Tabbed(tmpl, tmplData)
 }
 

--- a/api/pkg/cli/cmd/info/info_test.go
+++ b/api/pkg/cli/cmd/info/info_test.go
@@ -61,10 +61,12 @@ var taskResWithLatestVersion = &res.ResourceVersionData{
 	},
 }
 
+var deprecated = true
 var taskResWithOldVersion = &res.ResourceVersionData{
 	ID:                  12,
 	Version:             "0.1",
 	Description:         "Description for task foo-bar version 0.1",
+	Deprecated:          &deprecated,
 	MinPipelinesVersion: "0.12",
 	RawURL:              "http://raw.github.url/foo-bar/",
 	WebURL:              "http://web.github.com/foo-bar/",

--- a/api/pkg/cli/cmd/info/testdata/TestInfoTask_WithOldVersion.golden
+++ b/api/pkg/cli/cmd/info/testdata/TestInfoTask_WithOldVersion.golden
@@ -1,6 +1,6 @@
 📦 Name: foo-bar
 
-📌 Version: 0.1
+📌 Version: 0.1 (Deprecated)
 
 📖 Description: Description for task foo-bar version 0.1
 

--- a/api/pkg/cli/formatter/field.go
+++ b/api/pkg/cli/formatter/field.go
@@ -124,9 +124,12 @@ func findSpaceIndexFromLast(str string) int {
 
 // FormatVersion returns version appended with (latest) if the
 // latest field passed is true
-func FormatVersion(version string, latest bool) string {
+func FormatVersion(version string, latest bool, deprecated bool) string {
 	if latest {
 		return version + " (Latest)"
+	}
+	if deprecated {
+		return version + " (Deprecated)"
 	}
 	return version
 }

--- a/api/pkg/cli/formatter/field_test.go
+++ b/api/pkg/cli/formatter/field_test.go
@@ -80,10 +80,13 @@ func TestWrapText(t *testing.T) {
 }
 
 func TestFormatVersion(t *testing.T) {
-	got := FormatVersion("0.1", false)
+	got := FormatVersion("0.1", false, false)
 	assert.Equal(t, "0.1", got)
 
-	got = FormatVersion("0.1", true)
+	got = FormatVersion("0.1", false, true)
+	assert.Equal(t, "0.1 (Deprecated)", got)
+
+	got = FormatVersion("0.1", true, false)
 	assert.Equal(t, "0.1 (Latest)", got)
 }
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

    
- This patch adds deprecation info along with version
   for a deprecated version of a resource
    
    Signed-off-by: Shiv Verma <shverma@redhat.com>



![Screenshot from 2021-07-19 16-29-40](https://user-images.githubusercontent.com/31416465/126150261-7782588c-5514-4eaa-9959-f6bf4a776976.png)

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [x] Run API Unit Tests, Lint Checks, API Design, Golden Files with `make api-check`
- [x] Run UI Unit Tests, Lint Checks with `make ui-check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._
