### PR TITLE
CLI: Updates `tkn hub install task` cli command for --version flag to add deprecation warning

### DIFF
--- a/api/pkg/cli/cmd/install/install.go
+++ b/api/pkg/cli/cmd/install/install.go
@@ -29,8 +29,9 @@ import (
 )
 
 const (
-	defaultCatalog = "tekton"
-	versionLabel   = "app.kubernetes.io/version"
+	defaultCatalog        = "tekton"
+	versionLabel          = "app.kubernetes.io/version"
+	deprecationAnnotation = "tekton.dev/deprecated"
 )
 
 type options struct {
@@ -151,6 +152,10 @@ func (opts *options) run() error {
 		} else {
 			return opts.errors(resourceInstaller.GetPipelineVersion(), errors)
 		}
+	}
+
+	if opts.resource.GetAnnotations()[deprecationAnnotation] == "true" {
+		_ = printer.New(out).String("WARN: This version has been deprecated")
 	}
 
 	return printer.New(out).String(msg(opts.resource))

--- a/api/pkg/cli/cmd/install/testdata/foo-v0.2.yaml
+++ b/api/pkg/cli/cmd/install/testdata/foo-v0.2.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: foo
+  labels:
+    app.kubernetes.io/version: '0.2'
+  annotations:
+    tekton.dev/pipelines.minVersion: '0.13.1'
+    tekton.dev/tags: cli
+    tekton.dev/displayName: 'foo-bar'
+    tekton.dev/deprecated: 'true'
+spec:
+  description: >-
+    v0.2 Task to run foo


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This patch adds deprecation warning when users install
a deprecation version of a resource

Signed-off-by: Shiv Verma <shverma@redhat.com>

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [x] Run API Unit Tests, Lint Checks, API Design, Golden Files with `make api-check`
- [ ] Run UI Unit Tests, Lint Checks with `make ui-check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._
