### PR TITLE
UI: Deletes existing tag params before appending new tags to it

### DIFF
--- a/ui/src/utils/updateUrl.ts
+++ b/ui/src/utils/updateUrl.ts
@@ -51,6 +51,7 @@ export const UpdateURL = (
   // Sets tag params
   if (tags.length > 0) {
     searchParams.delete(Params.Query);
+    searchParams.delete(Params.Tag);
     tags.forEach((t: string) => {
       searchParams.append(Params.Tag, t);
     });


### PR DESCRIPTION
While refreshing the page tag params were getting duplicate
to avoid it needs to delete the existing tag params

Signed-off-by: Shiv Verma <shverma@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Run API Unit Tests, Lint Checks, API Design, Golden Files with `make api-check`
- [ ] Run UI Unit Tests, Lint Checks with `make ui-check`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._
