### PR TITLE
Remove username formatting(convert lowercase) while saving the user

### DIFF
--- a/api/pkg/service/auth/auth.go
+++ b/api/pkg/service/auth/auth.go
@@ -132,7 +132,7 @@ func (r *request) addUser(ghUser *github.User) (*model.User, error) {
 		if err == gorm.ErrRecordNotFound {
 
 			user.GithubName = ghUser.GetName()
-			user.GithubLogin = strings.ToLower(ghUser.GetLogin())
+			user.GithubLogin = ghUser.GetLogin()
 			user.Type = model.NormalUserType
 			user.AvatarURL = ghUser.GetAvatarURL()
 
@@ -155,8 +155,10 @@ func (r *request) addUser(ghUser *github.User) (*model.User, error) {
 		user.GithubName = ghUser.GetName()
 		user.Type = model.NormalUserType
 	}
-	// For existing user, check if URL is not added
-	if user.AvatarURL == "" {
+
+	// For existing user, check if URL is not added or github-login is incorrect
+	if user.AvatarURL == "" || user.GithubLogin != ghUser.GetLogin() {
+		user.GithubLogin = ghUser.GetLogin()
 		user.AvatarURL = ghUser.GetAvatarURL()
 		if err = r.db.Save(&user).Error; err != nil {
 			r.log.Error(err)

--- a/api/pkg/service/auth/auth_test.go
+++ b/api/pkg/service/auth/auth_test.go
@@ -277,3 +277,63 @@ func TestLogin_UserAddedByConfig(t *testing.T) {
 
 	assert.Equal(t, gock.IsDone(), true)
 }
+
+func TestLogin_UserWitMixedUSerName(t *testing.T) {
+	tc := testutils.Setup(t)
+	testutils.LoadFixtures(t, tc.FixturePath())
+
+	defer gock.Off()
+
+	gock.New("https://github.com").
+		Post("/login/oauth/access_token").
+		Reply(200).
+		JSON(map[string]string{
+			"access_token": "test-token",
+		})
+
+	gock.New("https://api.github.com").
+		Get("/user").
+		Reply(200).
+		JSON(map[string]string{
+			"login":      "conFIG-UsER",
+			"name":       "config-user",
+			"avatar_url": "http://config",
+		})
+
+	// Mocks the time
+	token.Now = testutils.Now
+
+	//get old user id
+	old_user := model.User{}
+	err := tc.DB().Where("github_login = ?", "config-user").First(&old_user).Error
+	assert.NoError(t, err)
+
+	authSvc := New(tc)
+	payload := &auth.AuthenticatePayload{Code: "test-code"}
+	res, err := authSvc.Authenticate(context.Background(), payload)
+	assert.NoError(t, err)
+
+	// validate the github login of user after login
+	ut := &model.User{}
+	err = tc.DB().Where("github_login = ?", "conFIG-UsER").First(ut).Error
+	assert.NoError(t, err)
+	// check shouldn't create no new user due to mixed user name 
+	assert.Equal(t, old_user.ID, ut.ID)
+
+	// expected refresh jwt for user
+	user, refreshToken, err := tc.RefreshTokenForUser("conFIG-UsER")
+	assert.Equal(t, user.GithubLogin, "conFIG-UsER")
+	assert.NoError(t, err)
+
+	accessExpiryTime := testutils.Now().Add(tc.JWTConfig().AccessExpiresIn).Unix()
+	refreshExpiryTime := testutils.Now().Add(tc.JWTConfig().RefreshExpiresIn).Unix()
+
+	assert.Equal(t, tc.JWTConfig().AccessExpiresIn.String(), res.Data.Access.RefreshInterval)
+	assert.Equal(t, accessExpiryTime, res.Data.Access.ExpiresAt)
+
+	assert.Equal(t, refreshToken, res.Data.Refresh.Token)
+	assert.Equal(t, tc.JWTConfig().RefreshExpiresIn.String(), res.Data.Refresh.RefreshInterval)
+	assert.Equal(t, refreshExpiryTime, res.Data.Refresh.ExpiresAt)
+
+	assert.Equal(t, gock.IsDone(), true)
+}


### PR DESCRIPTION
Resolves: #288

# Changes
- Update user exists check logic for both lowercase & mixed-case username
    - Using `LOWER(github_login)` to prevent if user changed his username from mixed-case to lowercase in GitHub.
- Store updated username if the username in database is incorrect.
- Update existing testcase to support when new username contains mixed-case letters.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [x] Run API Unit Tests, Lint Checks, API Design, Golden Files with `make api-check`
- [x] Run UI Unit Tests, Lint Checks with `make ui-check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)
