### PR TITLE
Adds Categories support to Hub CLI and `-o wide` flag in search command

### DIFF
--- a/api/pkg/cli/cmd/info/info.go
+++ b/api/pkg/cli/cmd/info/info.go
@@ -51,6 +51,13 @@ const resTemplate = `{{ icon "name" }}Name: {{ .Resource.Name }}
 
 {{ icon "rating" }}Rating: {{ .Resource.Rating }}
 
+{{ $t := len .Resource.Categories }}{{ if ne $t 0 }}
+{{- icon "categories" }}Categories
+ {{- range $p := .Resource.Categories }}
+  {{ icon "bullet" }}{{ $p.Name }}
+ {{- end }}
+{{- end }}
+
 {{ $t := len .Resource.Tags }}{{ if ne $t 0 }}
 {{- icon "tags" }}Tags
  {{- range $p := .Resource.Tags }}

--- a/api/pkg/cli/cmd/info/info_test.go
+++ b/api/pkg/cli/cmd/info/info_test.go
@@ -52,6 +52,12 @@ var taskResWithLatestVersion = &res.ResourceVersionData{
 			Type: "community",
 		},
 		Rating: 4,
+		Categories: []*res.Category{
+			{
+				ID:   1,
+				Name: "foo-bar",
+			},
+		},
 		Tags: []*res.Tag{
 			{
 				ID:   3,
@@ -81,6 +87,12 @@ var taskResWithOldVersion = &res.ResourceVersionData{
 			Type: "community",
 		},
 		Rating: 4,
+		Categories: []*res.Category{
+			{
+				ID:   1,
+				Name: "foo-bar",
+			},
+		},
 		Tags: []*res.Tag{
 			{
 				ID:   3,

--- a/api/pkg/cli/cmd/info/testdata/TestInfoTask_WithLatestVersion.golden
+++ b/api/pkg/cli/cmd/info/testdata/TestInfoTask_WithLatestVersion.golden
@@ -8,6 +8,9 @@
 
 ⭐ ️Rating: 4
 
+🏷️  ️Categories
+  ∙ foo-bar
+
 🏷 Tags
   ∙ foo
 

--- a/api/pkg/cli/cmd/info/testdata/TestInfoTask_WithOldVersion.golden
+++ b/api/pkg/cli/cmd/info/testdata/TestInfoTask_WithOldVersion.golden
@@ -8,6 +8,9 @@
 
 ⭐ ️Rating: 4
 
+🏷️  ️Categories
+  ∙ foo-bar
+
 🏷 Tags
   ∙ foo
 

--- a/api/pkg/cli/cmd/info/testdata/TestPipelineTask_MultiLineDescription.golden
+++ b/api/pkg/cli/cmd/info/testdata/TestPipelineTask_MultiLineDescription.golden
@@ -12,6 +12,9 @@
 
 ⭐ ️Rating: 4
 
+🏷️  ️Categories
+  ∙ foo-bar
+
 🏷 Tags
   ∙ foo
 

--- a/api/pkg/cli/cmd/search/search.go
+++ b/api/pkg/cli/cmd/search/search.go
@@ -31,9 +31,19 @@ import (
 const resTemplate = `{{- $rl := len .Resources }}{{ if eq $rl 0 -}}
 No Resources found
 {{ else -}}
-NAME	KIND	CATALOG	DESCRIPTION	TAGS
+NAME	KIND	CATALOG	DESCRIPTION	TAGS	CATEGORIES
 {{ range $_, $r := .Resources -}}
-{{ formatName $r.Name $r.LatestVersion.Version }}	{{ $r.Kind }}	{{ formatCatalogName $r.Catalog.Name }}	{{ formatDesc $r.LatestVersion.Description 40 }}	{{ formatTags $r.Tags }}
+{{ formatName $r.Name $r.LatestVersion.Version }}	{{ $r.Kind }}	{{ formatCatalogName $r.Catalog.Name }}	{{ formatDesc $r.LatestVersion.Description 40 }}	{{ formatTags $r.Tags }}	{{ formatCategories $r.Categories }}
+{{ end }}
+{{- end -}}
+`
+
+const minResTemplate = `{{- $rl := len .Resources }}{{ if eq $rl 0 -}}
+No Resources found
+{{ else -}}
+NAME	KIND	CATALOG	DESCRIPTION
+{{ range $_, $r := .Resources -}}
+{{ formatName $r.Name $r.LatestVersion.Version }}	{{ $r.Kind }}	{{ formatCatalogName $r.Catalog.Name }}	{{ formatDesc $r.LatestVersion.Description 40 }}
 {{ end }}
 {{- end -}}
 `
@@ -44,18 +54,21 @@ var (
 		"formatCatalogName": formatter.FormatCatalogName,
 		"formatDesc":        formatter.FormatDesc,
 		"formatTags":        formatter.FormatTags,
+		"formatCategories":  formatter.FormatCategories,
 	}
-	tmpl = template.Must(template.New("List Resources").Funcs(funcMap).Parse(resTemplate))
+	tmpl    = template.Must(template.New("List Resources").Funcs(funcMap).Parse(resTemplate))
+	minTmpl = template.Must(template.New("List Resources").Funcs(funcMap).Parse(minResTemplate))
 )
 
 type options struct {
-	cli    app.CLI
-	limit  uint
-	match  string
-	output string
-	tags   []string
-	kinds  []string
-	args   []string
+	cli        app.CLI
+	limit      uint
+	match      string
+	output     string
+	tags       []string
+	categories []string
+	kinds      []string
+	args       []string
 }
 
 var examples string = `
@@ -76,7 +89,7 @@ func Command(cli app.CLI) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "search",
-		Short:   "Search resource by a combination of name, kind, and tags",
+		Short:   "Search resource by a combination of name, kind, categories and tags",
 		Long:    ``,
 		Example: examples,
 		Annotations: map[string]string{
@@ -94,7 +107,8 @@ func Command(cli app.CLI) *cobra.Command {
 	cmd.Flags().StringVar(&opts.match, "match", "contains", "Accept type of search. 'exact' or 'contains'.")
 	cmd.Flags().StringArrayVar(&opts.kinds, "kinds", nil, "Accepts a comma separated list of kinds")
 	cmd.Flags().StringArrayVar(&opts.tags, "tags", nil, "Accepts a comma separated list of tags")
-	cmd.Flags().StringVarP(&opts.output, "output", "o", "table", "Accepts output format: [table, json]")
+	cmd.Flags().StringArrayVar(&opts.categories, "categories", nil, "Accepts a comma separated list of categories")
+	cmd.Flags().StringVarP(&opts.output, "output", "o", "table", "Accepts output format: [table, json, wide]")
 
 	return cmd
 }
@@ -108,11 +122,12 @@ func (opts *options) run() error {
 	hubClient := opts.cli.Hub()
 
 	result := hubClient.Search(hub.SearchOption{
-		Name:  opts.name(),
-		Kinds: opts.kinds,
-		Tags:  opts.tags,
-		Match: opts.match,
-		Limit: opts.limit,
+		Name:       opts.name(),
+		Kinds:      opts.kinds,
+		Tags:       opts.tags,
+		Categories: opts.categories,
+		Match:      opts.match,
+		Limit:      opts.limit,
 	})
 
 	out := opts.cli.Stream().Out
@@ -125,32 +140,36 @@ func (opts *options) run() error {
 	if err != nil {
 		return err
 	}
-
 	var templateData = struct {
 		Resources hub.SearchResponse
 	}{
 		Resources: typed,
 	}
+	if opts.output == "wide" {
+		return printer.New(out).Tabbed(tmpl, templateData)
+	} else {
+		return printer.New(out).Tabbed(minTmpl, templateData)
+	}
 
-	return printer.New(out).Tabbed(tmpl, templateData)
 }
 
 func (opts *options) validate() error {
 
-	if flag.AllEmpty(opts.args, opts.kinds, opts.tags) {
-		return fmt.Errorf("please specify a resource name, --tags or --kinds flag to search")
+	if flag.AllEmpty(opts.args, opts.kinds, opts.tags, opts.categories) {
+		return fmt.Errorf("please specify a resource name, --tags, --categories or --kinds flag to search")
 	}
 
 	if err := flag.InList("match", opts.match, []string{"contains", "exact"}); err != nil {
 		return err
 	}
 
-	if err := flag.InList("output", opts.output, []string{"table", "json"}); err != nil {
+	if err := flag.InList("output", opts.output, []string{"table", "json", "wide"}); err != nil {
 		return err
 	}
 
 	opts.kinds = flag.TrimArray(opts.kinds)
 	opts.tags = flag.TrimArray(opts.tags)
+	opts.categories = flag.TrimArray(opts.categories)
 
 	for _, k := range opts.kinds {
 		if !parser.IsSupportedKind(k) {

--- a/api/pkg/cli/cmd/search/search_test.go
+++ b/api/pkg/cli/cmd/search/search_test.go
@@ -106,7 +106,7 @@ func TestValidate_ErrorCases(t *testing.T) {
 	opt := options{}
 	err := opt.validate()
 	assert.Error(t, err)
-	assert.EqualError(t, err, "please specify a resource name, --tags or --kinds flag to search")
+	assert.EqualError(t, err, "please specify a resource name, --tags, --categories or --kinds flag to search")
 
 	opt = options{
 		kinds:  []string{"abc"},
@@ -133,7 +133,7 @@ func TestValidate_ErrorCases(t *testing.T) {
 	}
 	err = opt.validate()
 	assert.Error(t, err)
-	assert.EqualError(t, err, "invalid value \"abc\" set for option output. Valid options: [table, json]")
+	assert.EqualError(t, err, "invalid value \"abc\" set for option output. Valid options: [table, json, wide]")
 }
 
 func TestSearch_TableFormat(t *testing.T) {
@@ -155,7 +155,7 @@ func TestSearch_TableFormat(t *testing.T) {
 		cli:    cli,
 		args:   []string{"foo"},
 		match:  "contains",
-		output: "table",
+		output: "wide",
 	}
 
 	err := opt.run()

--- a/api/pkg/cli/cmd/search/testdata/TestSearch_TableFormat.golden
+++ b/api/pkg/cli/cmd/search/testdata/TestSearch_TableFormat.golden
@@ -1,3 +1,3 @@
-NAME            KIND       CATALOG   DESCRIPTION                                  TAGS
-foo (0.1)       Task       Tekton    Description for task abc version 0.1         tag3, tag1
-foo-bar (0.2)   Pipeline   Foo       Description for pipeline foo-bar versio...   ---
+NAME            KIND       CATALOG   DESCRIPTION                                  TAGS         CATEGORIES
+foo (0.1)       Task       Tekton    Description for task abc version 0.1         tag3, tag1   ---
+foo-bar (0.2)   Pipeline   Foo       Description for pipeline foo-bar versio...   ---          ---

--- a/api/pkg/cli/formatter/field.go
+++ b/api/pkg/cli/formatter/field.go
@@ -34,6 +34,7 @@ var icons = map[string]string{
 	"rating":             "⭐ ️",
 	"tags":               "🏷 ",
 	"install":            "⚒ ",
+	"categories":         "🏷️  ️",
 }
 
 // FormatName returns name of resource with its latest version

--- a/api/pkg/cli/formatter/field.go
+++ b/api/pkg/cli/formatter/field.go
@@ -74,6 +74,22 @@ func FormatTags(tags []*client.TagResponseBody) string {
 	return sb.String()
 }
 
+// FormatCategories returns list of categories seperated by comma
+func FormatCategories(categories []*client.CategoryResponseBody) string {
+	var sb strings.Builder
+	if len(categories) == 0 {
+		return "---"
+	}
+	for i, c := range categories {
+		if i != len(categories)-1 {
+			sb.WriteString(strings.Trim(*c.Name, " ") + ", ")
+			continue
+		}
+		sb.WriteString(strings.Trim(*c.Name, " "))
+	}
+	return sb.String()
+}
+
 // WrapText returns description broken down in multiple lines with
 // max width passed to it
 // titleLength would be the length of title on left hand side before the

--- a/api/pkg/cli/formatter/field_test.go
+++ b/api/pkg/cli/formatter/field_test.go
@@ -68,6 +68,28 @@ func TestFormatTags(t *testing.T) {
 	assert.Equal(t, "---", tags)
 }
 
+func TestFormatCategories(t *testing.T) {
+
+	categoryName1 := "category1"
+	categoryName2 := "category2"
+
+	res := []*client.CategoryResponseBody{
+		{
+			Name: &categoryName1,
+		},
+		{
+			Name: &categoryName2,
+		},
+	}
+
+	categories := FormatCategories(res)
+	assert.Equal(t, "category1, category2", categories)
+
+	// No Categories
+	categories = FormatTags(nil)
+	assert.Equal(t, "---", categories)
+}
+
 func TestWrapText(t *testing.T) {
 
 	// Description of resource with just summa

--- a/api/pkg/cli/hub/search.go
+++ b/api/pkg/cli/hub/search.go
@@ -25,12 +25,13 @@ import (
 
 // SearchOption defines option associated with query API
 type SearchOption struct {
-	Name    string
-	Kinds   []string
-	Tags    []string
-	Match   string
-	Limit   uint
-	Catalog string
+	Name       string
+	Kinds      []string
+	Tags       []string
+	Categories []string
+	Match      string
+	Limit      uint
+	Catalog    string
 }
 
 // SearchResponse is the data object which is the search result
@@ -90,6 +91,9 @@ func (so SearchOption) Endpoint() string {
 	}
 	if len(so.Tags) != 0 {
 		addArraytoURL("tags", so.Tags, v)
+	}
+	if len(so.Categories) != 0 {
+		addArraytoURL("categories", so.Categories, v)
 	}
 	if so.Limit != 0 {
 		v.Set("limit", strconv.FormatUint(uint64(so.Limit), 10))


### PR DESCRIPTION
  - Adds categories in Info command
  - Adds categories in Search command
      -  Adds `-o wide` flag in search command to display all columns
  
![Screenshot from 2021-09-14 10-14-57](https://user-images.githubusercontent.com/32545638/133196463-1a054d6d-de83-4da7-a793-23bea3245d53.png)

Signed-off-by: Puneet Punamiya <ppunamiy@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [x] Run API Unit Tests, Lint Checks, API Design, Golden Files with `make api-check`
- [x] Run UI Unit Tests, Lint Checks with `make ui-check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._
