### PR TITLE
Return err if db-migration fails

### DIFF
--- a/api/cmd/db/main.go
+++ b/api/cmd/db/main.go
@@ -32,7 +32,7 @@ func main() {
 
 	logger := api.Logger("main")
 	if err = migration.Migrate(api); err != nil {
-		logger.Errorf("DB initialisation failed !!")
+		logger.Fatalf("DB initialisation failed !!")
 		return
 	}
 	logger.Info("DB initialisation successful !!")

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -50,7 +50,7 @@ Ensure you are in `ui` directory and logged in you image registry.
 docker build -t <image> . && docker push <image>
 ```
 
-Replace `<image>` with the registry and image name. 
+Replace `<image>` with the registry and image name.
 eg. `quay.io/<username>/ui`
 
 ### API & DB Migration Image
@@ -58,25 +58,29 @@ eg. `quay.io/<username>/ui`
 Ensure you are in `api` directory and logged in you image registry.
 
 Build the API image using below command
+
 ```
 docker build -t <image> . && docker push <image>
 ```
 
-Replace `<image>` with the registry and image name. 
+Replace `<image>` with the registry and image name.
 eg. `quay.io/<username>/api`
 
 Now, Build the Db migration image using below command
+
 ```
 docker build -f db.Dockerfile -t <image> . && docker push <image>
 ```
 
-Replace `<image>` with the registry and image name. 
+Replace `<image>` with the registry and image name.
 eg. `quay.io/<username>/db-migration`
 
 Make sure all images are public before creating deployments.
 
 ---
+
 > ### NOTE: In case of using Github Enterprise make sure you deploy Hub in the same network where Github Enterprise server is running. Example if your Github Enterprise is running behind VPN then your Kubernetes Cluster should also be behind VPN.
+
 ---
 
 ## Deploy Database
@@ -120,13 +124,13 @@ db-589d44fdd5-ksf8v    1/1     Running     0          50s
 db-migration-8vhpd     0/1     Completed   0          17s
 ```
 
-You can also check the logs using `kubectl logs -n tekton-hub db-migration-8vhpd`
-
-The migration logs at the end should show
+The `Pod` will go into `Completed` state if the job succeeds. You can also check the logs using `kubectl logs -n tekton-hub db-migration-8vhpd`. In case of any failure the `Pod` will go into `Error` state.
 
 ```bash
-2020-09-22T15:35:16.412Z INFO migration/migration.go:91 Migration ran successfully !! {"service": "migration"}
-2020-09-22T15:35:16.412Z INFO db/main.go:39 DB initialisation successful !! {"service": "main"}
+$ kubectl get pods -n tekton-hub
+NAME                   READY   STATUS      RESTARTS   AGE
+db-589d44fdd5-ksf8v    1/1     Running     0          50s
+db-migration-8vhpd     0/1     Error       0          17s
 ```
 
 ## Deploy API Service
@@ -134,11 +138,12 @@ The migration logs at the end should show
 ### Update API Secret
 
 Edit `02-api/20-api-secret.yaml` and update the configuration
-- Create a GitHub OAuth with `Homepage URL` and `Authorization callback URL` as `http://localhost:5000`. We will update this URL once we deploy the UI pod. Follow the steps given [here][oauth-steps] to create a GitHub OAuth.  
+
+- Create a GitHub OAuth with `Homepage URL` and `Authorization callback URL` as `http://localhost:5000`. We will update this URL once we deploy the UI pod. Follow the steps given [here][oauth-steps] to create a GitHub OAuth.
 - After creating the OAuth add the Client ID and Client Secret in the yaml file.
 - For JWT_SIGNING_KEY, you can add any random string, this is used to sign the JWT created for users.
 - For `ACCESS_JWT_EXPIRES_IN` and `REFRESH_JWT_EXPIRES_IN` add time you want the jwt to be expired in. Refresh time should be greater than Access time.
-eg. 1m = 1 minute, 1h = 1 hour, 1d = 1 day
+  eg. 1m = 1 minute, 1h = 1 hour, 1d = 1 day
 
 ```yaml
 apiVersion: v1
@@ -249,6 +254,7 @@ Let's deploy the UI first and then we will add the resources in db.
 Edit `config/10-config.yaml` and set your GitHub OAuth Client ID and the API URL.
 
 You can get the API URL using below command (OpenShift)
+
 ```
   kubectl get -n tekton-hub routes api --template='https://{{ .spec.host }}'
 ```
@@ -412,15 +418,17 @@ NOTE: The catalog refresh will add new resources or update existing resource if 
    stringData:
      HUB_TOKEN: hub token
    ```
-    Set the token created in last step as Hub token.
 
-4. Apply the YAMLs 
+   Set the token created in last step as Hub token.
 
-    ```
-    kubectl apply -f 05-catalog-refresh-cj/ -n tekton-hub
-    ```
-    The cron job is configured to run every 30 min, you can change the interval in `05-catalog-refresh-cj/51-catalog-refresh-cronjob.yaml`.
-    
+5. Apply the YAMLs
+
+   ```
+   kubectl apply -f 05-catalog-refresh-cj/ -n tekton-hub
+   ```
+
+   The cron job is configured to run every 30 min, you can change the interval in `05-catalog-refresh-cj/51-catalog-refresh-cronjob.yaml`.
+
 ## Adding New Users in Config
 
 By default when any user login for the first time, they will have only default scope even if they are added in config.yaml. To get additinal scopes, make sure the user has logged in once.
@@ -433,50 +441,54 @@ curl -X POST -H "Authorization: <access-token>" \
     --data '{"force": true} \
   <api-route>/system/config/refresh
 ```
-Replace `<access-token>` with your JWT token. you must have `config-refresh` scope to call this API. 
+
+Replace `<access-token>` with your JWT token. you must have `config-refresh` scope to call this API.
 
 ## Deploying on Disconnected Cluster
 
 - To deploy on a disconnected cluster you need to fork the [tektoncd/catalog][catalog] or you can use your own catalog but it must follow the [Catalog TEP][catalog-tep].
 - Fork the tektoncd/hub and update the [hub config][hub-config] file for your catalog details.
-    - Update the catalog details with your catalog
-    ```
-    catalogs:
-      - name: tekton
-        org: tektoncd
-        type: community
-        url: https://github.com/tektoncd/catalog
-        revision: main
-    ```
-    You can find the template at bottom of [hub config][hub-config] file.
-- Mirror the Hub Deployment Images to the registry disconnected cluster has access to. 
-You can use release images or build your own. For hub release images, you can use latest release tag as image tag. for eg. `quay.io/tekton-hub/ui:v1.3.0`. You can check the latest release [here][hub-releases].
+  - Update the catalog details with your catalog
+  ```
+  catalogs:
+    - name: tekton
+      org: tektoncd
+      type: community
+      url: https://github.com/tektoncd/catalog
+      revision: main
+  ```
+  You can find the template at bottom of [hub config][hub-config] file.
+- Mirror the Hub Deployment Images to the registry disconnected cluster has access to.
+  You can use release images or build your own. For hub release images, you can use latest release tag as image tag. for eg. `quay.io/tekton-hub/ui:v1.3.0`. You can check the latest release [here][hub-releases].
 - List of images to be mirrored
-    - UI - `quay.io/tekton-hub/ui`
-    - API - `quay.io/tekton-hub/api`
-    - DB-Migration - `quay.io/tekton-hub/db-migration`
-    - DB - `postgres:13@sha256:260a98d976574b439712c35914fdcb840755233f79f3e27ea632543f78b7a21e`
 
-    You can mirror the images using `oc` as below
-    ```
-    oc image mirror quay.io/tekton-hub/ui:v1.3.0 your.registry/project/ui:v1.3.0
-    ``` 
+  - UI - `quay.io/tekton-hub/ui`
+  - API - `quay.io/tekton-hub/api`
+  - DB-Migration - `quay.io/tekton-hub/db-migration`
+  - DB - `postgres:13@sha256:260a98d976574b439712c35914fdcb840755233f79f3e27ea632543f78b7a21e`
+
+  You can mirror the images using `oc` as below
+
+  ```
+  oc image mirror quay.io/tekton-hub/ui:v1.3.0 your.registry/project/ui:v1.3.0
+  ```
+
 - Now, follow the steps from [Deploy Database Section](#deploy-database) above. Make sure you update the images in deployment files before applying.
 
 ## Troubleshooting
 
 #### UI is not showing resources but catalog refresh is successful
+
 - If you have insecure connection the UI might not be able to hit the API.
 - So, hit the API URL in your browser `https://<api-url>` once you get the response as `status: ok`, refresh you UI.
 
 #### UI is not showing resources but catalog refresh is successful (Console Error)
+
 - Verify catalog refresh is successful by hitting the `/v1/resources` API using the API URL.
-- If is returning resources than check for console errors on UI. 
+- If is returning resources than check for console errors on UI.
 - Right click -> Inspect or (Ctrl + Shift + I) (For Chrome). Then click on console tab.
 - If there is cors error then check the UI config map and the URL you have added.
 - The URL should be for example `https://api.hub.tekton.dev` and not `https://api.hub.tekton.dev/` there shouldn't be `/` at the end.
-
-
 
 [ko]: https://github.com/google/ko
 [kubectl]: https://kubernetes.io/docs/tasks/tools/install-kubectl/
@@ -486,7 +498,7 @@ You can use release images or build your own. For hub release images, you can us
 [docker]: https://docs.docker.com/engine/install/
 [podman]: https://podman.io/getting-started/installation
 [config-yaml]: https://raw.githubusercontent.com/tektoncd/hub/master/config.yaml
-[oauth-steps]:https://docs.github.com/en/developers/apps/creating-an-oauth-app
-[catalog]:https://github.com/tektoncd/catalog
-[catalog-tep]:https://github.com/tektoncd/community/blob/main/teps/0003-tekton-catalog-organization.md
-[hub-config]:https://github.com/tektoncd/hub/blob/main/config.yaml
+[oauth-steps]: https://docs.github.com/en/developers/apps/creating-an-oauth-app
+[catalog]: https://github.com/tektoncd/catalog
+[catalog-tep]: https://github.com/tektoncd/community/blob/main/teps/0003-tekton-catalog-organization.md
+[hub-config]: https://github.com/tektoncd/hub/blob/main/config.yaml


### PR DESCRIPTION
# Changes

Earlier db-migration does not returns with error code if it fails and thus
we had to check the logs for the failure. With this PR if the migration
fails it will return an exit code and thus the job will fail.

Also updated the Deployment docs and also fixed some formatting of the
docs.

Signed-off-by: vinamra28 <vinjain@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Run API Unit Tests, Lint Checks, API Design, Golden Files with `make api-check`
- [ ] Run UI Unit Tests, Lint Checks with `make ui-check`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._
