### PR TITLE
Support Catalog refresh for different git providers

### DIFF
--- a/api/pkg/app/data.go
+++ b/api/pkg/app/data.go
@@ -40,6 +40,7 @@ type Catalog struct {
 	URL        string
 	ContextDir string
 	Revision   string
+	Provider   string
 }
 
 type Scope struct {

--- a/api/pkg/db/initializer/initializer.go
+++ b/api/pkg/db/initializer/initializer.go
@@ -116,6 +116,7 @@ func addCatalogs(db *gorm.DB, log *log.Logger, data *app.Data) error {
 			Org:        c.Org,
 			Type:       c.Type,
 			URL:        c.URL,
+			Provider:   c.Provider,
 			Revision:   c.Revision,
 			ContextDir: c.ContextDir,
 		}

--- a/api/pkg/db/migration/202109151102_add_provider_in_catalog_table.go
+++ b/api/pkg/db/migration/202109151102_add_provider_in_catalog_table.go
@@ -1,0 +1,36 @@
+// Copyright © 2021 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migration
+
+import (
+	"github.com/go-gormigrate/gormigrate/v2"
+	"github.com/tektoncd/hub/api/gen/log"
+	"github.com/tektoncd/hub/api/pkg/db/model"
+	"gorm.io/gorm"
+)
+
+func addProviderColumnInCatalogsTable(log *log.Logger) *gormigrate.Migration {
+
+	return &gormigrate.Migration{
+		ID: "202109151102_add_provider_in_catalog_table",
+		Migrate: func(db *gorm.DB) error {
+			if err := db.AutoMigrate(&model.Catalog{}); err != nil {
+				log.Error(err)
+				return err
+			}
+			return nil
+		},
+	}
+}

--- a/api/pkg/db/migration/migration.go
+++ b/api/pkg/db/migration/migration.go
@@ -40,6 +40,7 @@ func Migrate(api *app.APIBase) error {
 			updateResourcesCategoryTable(log),
 			createPlatformTables(log),
 			addDeprecatedColumnInResoureVersionTable(log),
+			addProviderColumnInCatalogsTable(log),
 		},
 	)
 

--- a/api/pkg/db/model/model.go
+++ b/api/pkg/db/model/model.go
@@ -44,6 +44,7 @@ type (
 		gorm.Model
 		Name       string `gorm:"uniqueIndex:uix_name_org"`
 		Org        string `gorm:"uniqueIndex:uix_name_org"`
+		Provider   string `gorm:"not null;default:github"`
 		Type       string `gorm:"not null;default:null"`
 		URL        string `gorm:"not null;default:null"`
 		Revision   string `gorm:"not null;default:null"`

--- a/api/pkg/service/catalog/syncer.go
+++ b/api/pkg/service/catalog/syncer.go
@@ -351,7 +351,14 @@ func (s *syncer) updateResourceVersions(
 		ver.Description = v.Description
 		ver.ModifiedAt = v.ModifiedAt
 		ver.MinPipelinesVersion = v.MinPipelinesVersion
-		ver.URL = fmt.Sprintf("%s/tree/%s/%s", catalog.URL, catalog.Revision, v.Path)
+		switch catalog.Provider {
+		case "github":
+			ver.URL = fmt.Sprintf("%s/tree/%s/%s", catalog.URL, catalog.Revision, v.Path)
+		case "bitbucket":
+			ver.URL = fmt.Sprintf("%s/src/%s/%s", catalog.URL, catalog.Revision, v.Path)
+		case "gitlab":
+			ver.URL = fmt.Sprintf("%s/-/blob/%s/%s", catalog.URL, catalog.Revision, v.Path)
+		}
 
 		txn.Save(&ver)
 		log.Infof(" Version: %d -> %s | Path: %s ", ver.ID, ver.Version, v.Path)

--- a/api/pkg/service/resource/resource.go
+++ b/api/pkg/service/resource/resource.go
@@ -31,12 +31,12 @@ type service struct {
 	app.Service
 }
 
-var replacerStrings = []string{"github.com", "raw.githubusercontent.com", "/tree/", "/"}
+var replacerStrings = []string{"github.com", "raw.githubusercontent.com", "/tree/", "/", "/blob/", "/raw/", "/src/", "/raw/"}
 
 // Returns a replacer object which replaces a list of strings with replacements.
 // This function basically helps create the raw URL
-func getStringReplacer(resourceUrl string) *strings.Replacer {
-	if !strings.HasPrefix(resourceUrl, "https://github.com") {
+func getStringReplacer(resourceUrl, provider string) *strings.Replacer {
+	if !strings.HasPrefix(resourceUrl, "https://github.com") && provider == "github" {
 		parsedUrl, _ := url.Parse(resourceUrl)
 		host := "raw." + parsedUrl.Host
 		replacerStrings = append(replacerStrings, parsedUrl.Host, host)
@@ -301,7 +301,7 @@ func initResource(r model.Resource) *resource.ResourceData {
 		DisplayName:         lv.DisplayName,
 		MinPipelinesVersion: lv.MinPipelinesVersion,
 		WebURL:              lv.URL,
-		RawURL:              getStringReplacer(lv.URL).Replace(lv.URL),
+		RawURL:              getStringReplacer(lv.URL, r.Catalog.Provider).Replace(lv.URL),
 		UpdatedAt:           lv.ModifiedAt.UTC().Format(time.RFC3339),
 		Platforms:           platforms,
 	}
@@ -353,7 +353,7 @@ func minVersionInfo(r model.ResourceVersion) *resource.ResourceVersionData {
 
 	res := tinyVersionInfo(r)
 	res.WebURL = r.URL
-	res.RawURL = getStringReplacer(r.URL).Replace(r.URL)
+	res.RawURL = getStringReplacer(r.URL, r.Resource.Catalog.Provider).Replace(r.URL)
 	platforms := []*resource.Platform{}
 	for _, platform := range r.Platforms {
 		platforms = append(platforms, &resource.Platform{
@@ -422,7 +422,7 @@ func versionInfoFromResource(r model.Resource) *resource.ResourceVersion {
 		DisplayName:         v.DisplayName,
 		MinPipelinesVersion: v.MinPipelinesVersion,
 		WebURL:              v.URL,
-		RawURL:              getStringReplacer(v.URL).Replace(v.URL),
+		RawURL:              getStringReplacer(v.URL, r.Catalog.Provider).Replace(v.URL),
 		UpdatedAt:           v.ModifiedAt.UTC().Format(time.RFC3339),
 		Resource:            res,
 		Platforms:           verPlatforms,

--- a/api/pkg/service/resource/resource_test.go
+++ b/api/pkg/service/resource/resource_test.go
@@ -231,7 +231,7 @@ func TestByID_NotFoundError(t *testing.T) {
 
 func TestCreationRawURL(t *testing.T) {
 	url := "https://ghe.myhost.com/org/repo/tree/main/task/name/0.1/name.yaml"
-	replacer := getStringReplacer(url)
+	replacer := getStringReplacer(url, "github")
 	rawUrl := replacer.Replace(url)
 	expected := "https://raw.ghe.myhost.com/org/repo/main/task/name/0.1/name.yaml"
 	assert.Equal(t, expected, rawUrl)
@@ -258,4 +258,28 @@ func TestLatestVersionDeprecationByID(t *testing.T) {
 	res, err := resourceSvc.ByID(context.Background(), payload)
 	assert.NoError(t, err)
 	assert.Equal(t, true, *res.Data.LatestVersion.Deprecated)
+}
+
+func TestCreationRawURLBitbucket(t *testing.T) {
+	url := "https://bitbucket.org/org/catalog/src/main/task/name/0.1/name.yaml"
+	replacer := getStringReplacer(url, "bitbucket")
+	rawUrl := replacer.Replace(url)
+	expected := "https://bitbucket.org/org/catalog/raw/main/task/name/0.1/name.yaml"
+	assert.Equal(t, expected, rawUrl)
+}
+
+func TestCreationRawURLGitlab(t *testing.T) {
+	url := "https://gitlab.com/org/catalog/-/blob/main/task/name/0.1/name.yaml"
+	replacer := getStringReplacer(url, "gitlab")
+	rawUrl := replacer.Replace(url)
+	expected := "https://gitlab.com/org/catalog/-/raw/main/task/name/0.1/name.yaml"
+	assert.Equal(t, expected, rawUrl)
+}
+
+func TestCreationRawURLGitlabEnterprise(t *testing.T) {
+	url := "https://gitlab.myhost.com/org/catalog/-/blob/main/task/name/0.1/name.yaml"
+	replacer := getStringReplacer(url, "gitlab")
+	rawUrl := replacer.Replace(url)
+	expected := "https://gitlab.myhost.com/org/catalog/-/raw/main/task/name/0.1/name.yaml"
+	assert.Equal(t, expected, rawUrl)
 }

--- a/api/test/fixtures/catalogs.yaml
+++ b/api/test/fixtures/catalogs.yaml
@@ -18,6 +18,7 @@
   type: official
   url: https:/github.com/tektoncd/catalog
   context_dir: /task
+  provider: github
   revision: master
   created_at: 2016-01-01 12:30:12 UTC
   updated_at: 2016-01-01 12:30:12 UTC
@@ -28,6 +29,7 @@
   type: community
   url: https:/github.com/tektoncd/catalog-community
   context_dir: /task
+  provider: github
   revision: master
   created_at: 2016-01-01 12:30:12 UTC
   updated_at: 2016-01-01 12:30:12 UTC
@@ -38,6 +40,7 @@
   type: enterprise
   url: https:/myghe.com/tektoncd/catalog-enterprise
   context_dir: /task
+  provider: github
   revision: master
   created_at: 2016-01-01 12:30:12 UTC
   updated_at: 2016-01-01 12:30:12 UTC

--- a/config.yaml
+++ b/config.yaml
@@ -38,6 +38,7 @@ catalogs:
   - name: tekton
     org: tektoncd
     type: community
+    provider: github
     url: https://github.com/tektoncd/catalog
     revision: main
 
@@ -61,3 +62,4 @@ default:
 #     url:  URL of repository
 #     revision: Branch of repository
 #     contextDir(Optional): Path to resource dir
+#     provider: Name of git provider such as github, gitlab, bitbucket


### PR DESCRIPTION
Currently hub supports generation of WebURL and RawURL of resources
which were coming from github only and if somebody adds their catalog
from different git providers such as gitlab and bitbucket then it fails
to generate accurate urls.

This commit adds one more field in config.yaml where user needs to
mention the git provider of the catalog which they want to add so that
it becomes easy to generate. Also a column is being added in the
database for the same and a supporting db-migration job.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Run API Unit Tests, Lint Checks, API Design, Golden Files with `make api-check`
- [ ] Run UI Unit Tests, Lint Checks with `make ui-check`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._
