### PR TITLE
Filter resources based on platforms

### DIFF
--- a/ui/src/common/params.ts
+++ b/ui/src/common/params.ts
@@ -4,5 +4,6 @@ export enum Params {
   Category = 'category',
   Kind = 'kind',
   Catalog = 'catalog',
+  Platform = 'platform',
   Tag = 'tag'
 }

--- a/ui/src/components/LeftPane/LeftPane.test.tsx
+++ b/ui/src/components/LeftPane/LeftPane.test.tsx
@@ -5,6 +5,7 @@ import { shallow } from 'enzyme';
 import KindFilter from '../../containers/KindFilter';
 import CatalogFilter from '../../containers/CatalogFilter';
 import CategoryFilter from '../../containers/CategoryFilter';
+import PlatformFilter from '../../containers/PlatformFilter';
 
 describe('LeftPane', () => {
   it('should find the components and match the count', () => {
@@ -14,6 +15,7 @@ describe('LeftPane', () => {
 
     expect(component.find(KindFilter).length).toEqual(1);
     expect(component.find(CatalogFilter).length).toEqual(1);
+    expect(component.find(PlatformFilter).length).toEqual(1);
     expect(component.find(CategoryFilter).length).toEqual(1);
   });
 });

--- a/ui/src/components/LeftPane/__snapshots__/LeftPane.test.tsx.snap
+++ b/ui/src/components/LeftPane/__snapshots__/LeftPane.test.tsx.snap
@@ -9,6 +9,9 @@ exports[`LeftPane should find the components and match the count 1`] = `
     <KindFilter />
   </GridItem>
   <GridItem>
+    <PlatformFilter />
+  </GridItem>
+  <GridItem>
     <CatalogFilter />
   </GridItem>
   <GridItem>

--- a/ui/src/components/LeftPane/index.tsx
+++ b/ui/src/components/LeftPane/index.tsx
@@ -4,6 +4,7 @@ import { GridItem, Grid } from '@patternfly/react-core';
 import CatalogFilter from '../../containers/CatalogFilter';
 import KindFilter from '../../containers/KindFilter';
 import CategoryFilter from '../../containers/CategoryFilter';
+import PlatformFilter from '../../containers/PlatformFilter';
 import Sort from '../../containers/SortDropDown';
 import './LeftPane.css';
 
@@ -15,6 +16,9 @@ const LeftPane: React.FC = () => {
       </GridItem>
       <GridItem>
         <KindFilter />
+      </GridItem>
+      <GridItem>
+        <PlatformFilter />
       </GridItem>
       <GridItem>
         <CatalogFilter />

--- a/ui/src/containers/App/__snapshots__/App.test.tsx.snap
+++ b/ui/src/containers/App/__snapshots__/App.test.tsx.snap
@@ -180,6 +180,45 @@ exports[`App should render the component correctly and match the snapshot 1`] = 
                                     </GridItem>
                                     <GridItem>
                                       <div className=\\"pf-l-grid__item\\">
+                                        <PlatformFilter>
+                                          <Filter store={{...}} header=\\"Platform\\">
+                                            <div>
+                                              <Grid>
+                                                <div className=\\"pf-l-grid\\">
+                                                  <GridItem span={6}>
+                                                    <div className=\\"pf-l-grid__item pf-m-6-col\\">
+                                                      <Text component=\\"h1\\" className=\\"hub-filter-header\\">
+                                                        <h1 data-pf-content={true} className=\\"hub-filter-header\\">
+                                                          Platform
+                                                        </h1>
+                                                      </Text>
+                                                    </div>
+                                                  </GridItem>
+                                                  <GridItem span={3}>
+                                                    <div className=\\"pf-l-grid__item pf-m-3-col\\">
+                                                      <Button variant=\\"plain\\" aria-label=\\"Clear\\" onClick={[Function: res]}>
+                                                        <button onClick={[Function: res]} aria-disabled={false} aria-label=\\"Clear\\" className=\\"pf-c-button pf-m-plain\\" disabled={false} tabIndex={[undefined]} type=\\"button\\" data-ouia-component-type=\\"PF4/Button\\" data-ouia-safe={true} data-ouia-component-id={2}>
+                                                          <TimesIcon color=\\"currentColor\\" size=\\"sm\\" noVerticalAlign={false}>
+                                                            <svg style={{...}} fill=\\"currentColor\\" height=\\"1em\\" width=\\"1em\\" viewBox=\\"0 0 352 512\\" aria-labelledby={{...}} aria-hidden={true} role=\\"img\\">
+                                                              <path d=\\"M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z\\" transform=\\"\\" />
+                                                            </svg>
+                                                          </TimesIcon>
+                                                        </button>
+                                                      </Button>
+                                                    </div>
+                                                  </GridItem>
+                                                  <GridItem span={12}>
+                                                    <div className=\\"pf-l-grid__item pf-m-12-col\\" />
+                                                  </GridItem>
+                                                </div>
+                                              </Grid>
+                                            </div>
+                                          </Filter>
+                                        </PlatformFilter>
+                                      </div>
+                                    </GridItem>
+                                    <GridItem>
+                                      <div className=\\"pf-l-grid__item\\">
                                         <CatalogFilter>
                                           <Filter store={{...}} header=\\"Catalog\\">
                                             <div>
@@ -197,7 +236,7 @@ exports[`App should render the component correctly and match the snapshot 1`] = 
                                                   <GridItem span={3}>
                                                     <div className=\\"pf-l-grid__item pf-m-3-col\\">
                                                       <Button variant=\\"plain\\" aria-label=\\"Clear\\" onClick={[Function: res]}>
-                                                        <button onClick={[Function: res]} aria-disabled={false} aria-label=\\"Clear\\" className=\\"pf-c-button pf-m-plain\\" disabled={false} tabIndex={[undefined]} type=\\"button\\" data-ouia-component-type=\\"PF4/Button\\" data-ouia-safe={true} data-ouia-component-id={2}>
+                                                        <button onClick={[Function: res]} aria-disabled={false} aria-label=\\"Clear\\" className=\\"pf-c-button pf-m-plain\\" disabled={false} tabIndex={[undefined]} type=\\"button\\" data-ouia-component-type=\\"PF4/Button\\" data-ouia-safe={true} data-ouia-component-id={3}>
                                                           <TimesIcon color=\\"currentColor\\" size=\\"sm\\" noVerticalAlign={false}>
                                                             <svg style={{...}} fill=\\"currentColor\\" height=\\"1em\\" width=\\"1em\\" viewBox=\\"0 0 352 512\\" aria-labelledby={{...}} aria-hidden={true} role=\\"img\\">
                                                               <path d=\\"M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z\\" transform=\\"\\" />
@@ -236,7 +275,7 @@ exports[`App should render the component correctly and match the snapshot 1`] = 
                                                   <GridItem span={3}>
                                                     <div className=\\"pf-l-grid__item pf-m-3-col\\">
                                                       <Button variant=\\"plain\\" aria-label=\\"Clear\\" onClick={[Function: res]}>
-                                                        <button onClick={[Function: res]} aria-disabled={false} aria-label=\\"Clear\\" className=\\"pf-c-button pf-m-plain\\" disabled={false} tabIndex={[undefined]} type=\\"button\\" data-ouia-component-type=\\"PF4/Button\\" data-ouia-safe={true} data-ouia-component-id={3}>
+                                                        <button onClick={[Function: res]} aria-disabled={false} aria-label=\\"Clear\\" className=\\"pf-c-button pf-m-plain\\" disabled={false} tabIndex={[undefined]} type=\\"button\\" data-ouia-component-type=\\"PF4/Button\\" data-ouia-safe={true} data-ouia-component-id={4}>
                                                           <TimesIcon color=\\"currentColor\\" size=\\"sm\\" noVerticalAlign={false}>
                                                             <svg style={{...}} fill=\\"currentColor\\" height=\\"1em\\" width=\\"1em\\" viewBox=\\"0 0 352 512\\" aria-labelledby={{...}} aria-hidden={true} role=\\"img\\">
                                                               <path d=\\"M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z\\" transform=\\"\\" />
@@ -283,7 +322,7 @@ exports[`App should render the component correctly and match the snapshot 1`] = 
                 </PageSection>
                 <Footer>
                   <Card className=\\"hub-footer-card\\">
-                    <article className=\\"pf-c-card hub-footer-card\\" tabIndex={[undefined]} data-ouia-component-type=\\"PF4/Card\\" data-ouia-safe={true} data-ouia-component-id={4}>
+                    <article className=\\"pf-c-card hub-footer-card\\" tabIndex={[undefined]} data-ouia-component-type=\\"PF4/Card\\" data-ouia-safe={true} data-ouia-component-id={5}>
                       <Grid>
                         <div className=\\"pf-l-grid\\">
                           <GridItem span={12} className=\\"hub-footer-info\\">

--- a/ui/src/containers/BasicDetails/BasicDetails.test.tsx
+++ b/ui/src/containers/BasicDetails/BasicDetails.test.tsx
@@ -22,7 +22,8 @@ jest.mock('react-router-dom', () => {
       return {
         name: 'buildah',
         catalog: 'tekton',
-        kind: 'Task'
+        kind: 'Task',
+        platform: 'linux/amd64'
       };
     }
   };

--- a/ui/src/containers/PlatformFilter/PlatformFilter.test.tsx
+++ b/ui/src/containers/PlatformFilter/PlatformFilter.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { when } from 'mobx';
+import { Checkbox } from '@patternfly/react-core';
+import { FakeHub } from '../../api/testutil';
+import { createProviderAndStore } from '../../store/root';
+import PlatformFilter from '.';
+
+const TESTDATA_DIR = `src/store/testdata`;
+const api = new FakeHub(TESTDATA_DIR);
+const { Provider, root } = createProviderAndStore(api);
+
+describe('PlatformFilter', () => {
+  it('finds the filter component and matches the count', (done) => {
+    const component = mount(
+      <Provider>
+        <PlatformFilter />
+      </Provider>
+    );
+
+    const { resources } = root;
+    when(
+      () => {
+        return !resources.isLoading;
+      },
+      () => {
+        setTimeout(() => {
+          const platforms = resources.platforms;
+          expect(platforms.items.size).toBe(4);
+          component.update();
+
+          const pf = component.find(PlatformFilter);
+          expect(pf.length).toEqual(1);
+
+          expect(component.debug()).toMatchSnapshot();
+
+          expect(component.find(Checkbox).length).toEqual(4);
+
+          done();
+        }, 0);
+      }
+    );
+  });
+});

--- a/ui/src/containers/PlatformFilter/__snapshots__/PlatformFilter.test.tsx.snap
+++ b/ui/src/containers/PlatformFilter/__snapshots__/PlatformFilter.test.tsx.snap
@@ -1,0 +1,84 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PlatformFilter finds the filter component and matches the count 1`] = `
+"<Provider>
+   
+  <PlatformFilter>
+    <Filter store={{...}} header=\\"Platform\\">
+      <div>
+        <Grid>
+          <div className=\\"pf-l-grid\\">
+            <GridItem span={6}>
+              <div className=\\"pf-l-grid__item pf-m-6-col\\">
+                <Text component=\\"h1\\" className=\\"hub-filter-header\\">
+                  <h1 data-pf-content={true} className=\\"hub-filter-header\\">
+                    Platform
+                  </h1>
+                </Text>
+              </div>
+            </GridItem>
+            <GridItem span={3}>
+              <div className=\\"pf-l-grid__item pf-m-3-col\\">
+                <Button variant=\\"plain\\" aria-label=\\"Clear\\" onClick={[Function: res]}>
+                  <button onClick={[Function: res]} aria-disabled={false} aria-label=\\"Clear\\" className=\\"pf-c-button pf-m-plain\\" disabled={false} tabIndex={[undefined]} type=\\"button\\" data-ouia-component-type=\\"PF4/Button\\" data-ouia-safe={true} data-ouia-component-id={1}>
+                    <TimesIcon color=\\"currentColor\\" size=\\"sm\\" noVerticalAlign={false}>
+                      <svg style={{...}} fill=\\"currentColor\\" height=\\"1em\\" width=\\"1em\\" viewBox=\\"0 0 352 512\\" aria-labelledby={{...}} aria-hidden={true} role=\\"img\\">
+                        <path d=\\"M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z\\" transform=\\"\\" />
+                      </svg>
+                    </TimesIcon>
+                  </button>
+                </Button>
+              </div>
+            </GridItem>
+            <GridItem span={12}>
+              <div className=\\"pf-l-grid__item pf-m-12-col\\">
+                <Checkbox className=\\"hub-filter-checkbox\\" label={{...}} isChecked={false} onChange={[Function: onChange]} aria-label=\\"controlled checkbox\\" id=\\"linux/amd64\\" name=\\"linux/amd64\\" isValid={true} isDisabled={false}>
+                  <div className=\\"pf-c-check hub-filter-checkbox\\">
+                    <input id=\\"linux/amd64\\" name=\\"linux/amd64\\" className=\\"pf-c-check__input\\" type=\\"checkbox\\" onChange={[Function (anonymous)]} aria-invalid={false} aria-label=\\"controlled checkbox\\" disabled={false} checked={false} />
+                    <label className=\\"pf-c-check__label\\" htmlFor=\\"linux/amd64\\">
+                      <div>
+                        Linux/amd64
+                      </div>
+                    </label>
+                  </div>
+                </Checkbox>
+                <Checkbox className=\\"hub-filter-checkbox\\" label={{...}} isChecked={false} onChange={[Function: onChange]} aria-label=\\"controlled checkbox\\" id=\\"linux/arm64\\" name=\\"linux/arm64\\" isValid={true} isDisabled={false}>
+                  <div className=\\"pf-c-check hub-filter-checkbox\\">
+                    <input id=\\"linux/arm64\\" name=\\"linux/arm64\\" className=\\"pf-c-check__input\\" type=\\"checkbox\\" onChange={[Function (anonymous)]} aria-invalid={false} aria-label=\\"controlled checkbox\\" disabled={false} checked={false} />
+                    <label className=\\"pf-c-check__label\\" htmlFor=\\"linux/arm64\\">
+                      <div>
+                        Linux/arm64
+                      </div>
+                    </label>
+                  </div>
+                </Checkbox>
+                <Checkbox className=\\"hub-filter-checkbox\\" label={{...}} isChecked={false} onChange={[Function: onChange]} aria-label=\\"controlled checkbox\\" id=\\"linux/ppc64le\\" name=\\"linux/ppc64le\\" isValid={true} isDisabled={false}>
+                  <div className=\\"pf-c-check hub-filter-checkbox\\">
+                    <input id=\\"linux/ppc64le\\" name=\\"linux/ppc64le\\" className=\\"pf-c-check__input\\" type=\\"checkbox\\" onChange={[Function (anonymous)]} aria-invalid={false} aria-label=\\"controlled checkbox\\" disabled={false} checked={false} />
+                    <label className=\\"pf-c-check__label\\" htmlFor=\\"linux/ppc64le\\">
+                      <div>
+                        Linux/ppc64le
+                      </div>
+                    </label>
+                  </div>
+                </Checkbox>
+                <Checkbox className=\\"hub-filter-checkbox\\" label={{...}} isChecked={false} onChange={[Function: onChange]} aria-label=\\"controlled checkbox\\" id=\\"linux/s390x\\" name=\\"linux/s390x\\" isValid={true} isDisabled={false}>
+                  <div className=\\"pf-c-check hub-filter-checkbox\\">
+                    <input id=\\"linux/s390x\\" name=\\"linux/s390x\\" className=\\"pf-c-check__input\\" type=\\"checkbox\\" onChange={[Function (anonymous)]} aria-invalid={false} aria-label=\\"controlled checkbox\\" disabled={false} checked={false} />
+                    <label className=\\"pf-c-check__label\\" htmlFor=\\"linux/s390x\\">
+                      <div>
+                        Linux/s390x
+                      </div>
+                    </label>
+                  </div>
+                </Checkbox>
+              </div>
+            </GridItem>
+          </div>
+        </Grid>
+      </div>
+    </Filter>
+  </PlatformFilter>
+   
+</Provider>"
+`;

--- a/ui/src/containers/PlatformFilter/index.tsx
+++ b/ui/src/containers/PlatformFilter/index.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { useObserver } from 'mobx-react';
+import Filter from '../../components/Filter';
+import { useMst } from '../../store/root';
+
+const PlatformFilter: React.FC = () => {
+  const { resources } = useMst();
+  return useObserver(() => <Filter store={resources.platforms} header="Platform" />);
+};
+
+export default PlatformFilter;

--- a/ui/src/containers/Resources/index.tsx
+++ b/ui/src/containers/Resources/index.tsx
@@ -19,7 +19,7 @@ import './Resources.css';
 
 const Resources: React.FC = observer(() => {
   const { resources, categories } = useMst();
-  const { catalogs, kinds, search, sortBy, searchedTags } = resources;
+  const { catalogs, kinds, platforms, search, sortBy, searchedTags } = resources;
 
   const history = useHistory();
 
@@ -27,6 +27,7 @@ const Resources: React.FC = observer(() => {
     const selectedcategories = categories.selectedByName.join(',');
     const selectedKinds = [...kinds.selected].join(',');
     const selectedCatalogs = catalogs.selectedByName.join(',');
+    const selectedPlatforms = platforms.selectedByName.join(',');
 
     const url = UpdateURL(
       search,
@@ -34,10 +35,19 @@ const Resources: React.FC = observer(() => {
       selectedcategories,
       selectedKinds,
       selectedCatalogs,
+      selectedPlatforms,
       searchedTags
     );
     if (!resources.isLoading) history.replace(`?${url}`);
-  }, [search, sortBy, categories.selectedByName, kinds.selected, catalogs.selected, searchedTags]);
+  }, [
+    search,
+    sortBy,
+    categories.selectedByName,
+    kinds.selected,
+    catalogs.selected,
+    platforms.selectedByName,
+    searchedTags
+  ]);
 
   const clearFilter = () => {
     resources.clearAllFilters();

--- a/ui/src/store/__snapshots__/platform.test.ts.snap
+++ b/ui/src/store/__snapshots__/platform.test.ts.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Store Object creates a platform store 1`] = `
+Object {
+  "1": Object {
+    "id": 1,
+    "name": "linux/amd64",
+    "selected": false,
+  },
+}
+`;

--- a/ui/src/store/__snapshots__/resource.test.ts.snap
+++ b/ui/src/store/__snapshots__/resource.test.ts.snap
@@ -15,6 +15,33 @@ Object {
 }
 `;
 
+exports[`Store functions creates a platform store 1`] = `
+Object {
+  "items": Object {
+    "1": Object {
+      "id": 1,
+      "name": "linux/amd64",
+      "selected": false,
+    },
+    "2": Object {
+      "id": 2,
+      "name": "linux/s390x",
+      "selected": false,
+    },
+    "3": Object {
+      "id": 3,
+      "name": "linux/ppc64le",
+      "selected": false,
+    },
+    "4": Object {
+      "id": 4,
+      "name": "linux/arm64",
+      "selected": false,
+    },
+  },
+}
+`;
+
 exports[`Store functions creates a resource store 1`] = `
 Object {
   "tekton-hub/Pipeline/hub": Object {
@@ -28,6 +55,10 @@ Object {
     "kind": "Pipeline",
     "latestVersion": 1,
     "name": "hub",
+    "platforms": Array [
+      1,
+      2,
+    ],
     "rating": 4.5,
     "readme": "",
     "resourceKey": "tekton-hub/Pipeline/hub",
@@ -51,6 +82,9 @@ Object {
     "kind": "Task",
     "latestVersion": 1,
     "name": "ansible-runner",
+    "platforms": Array [
+      1,
+    ],
     "rating": 4.5,
     "readme": "",
     "resourceKey": "tekton/Task/ansible-runner",
@@ -74,6 +108,9 @@ Object {
     "kind": "Task",
     "latestVersion": 4,
     "name": "aws-cli",
+    "platforms": Array [
+      1,
+    ],
     "rating": 5,
     "readme": "",
     "resourceKey": "tekton/Task/aws-cli",
@@ -97,6 +134,12 @@ Object {
     "kind": "Task",
     "latestVersion": 105,
     "name": "buildah",
+    "platforms": Array [
+      1,
+      4,
+      3,
+      2,
+    ],
     "rating": 4,
     "readme": "",
     "resourceKey": "tekton/Task/buildah",
@@ -120,6 +163,9 @@ Object {
     "kind": "Task",
     "latestVersion": 47,
     "name": "golang-build",
+    "platforms": Array [
+      1,
+    ],
     "rating": 5,
     "readme": "",
     "resourceKey": "tekton/Task/golang-build",
@@ -143,6 +189,9 @@ Object {
     "kind": "Task",
     "latestVersion": 104,
     "name": "jenkins",
+    "platforms": Array [
+      1,
+    ],
     "rating": 5,
     "readme": "",
     "resourceKey": "tekton/Task/jenkins",
@@ -167,6 +216,9 @@ Object {
     "kind": "Task",
     "latestVersion": 57,
     "name": "jib-maven",
+    "platforms": Array [
+      1,
+    ],
     "rating": 5,
     "readme": "",
     "resourceKey": "tekton/Task/jib-maven",
@@ -195,6 +247,10 @@ Object {
     "kind": "Pipeline",
     "latestVersion": 1,
     "name": "hub",
+    "platforms": Array [
+      1,
+      2,
+    ],
     "rating": 4.5,
     "readme": "",
     "resourceKey": "tekton-hub/Pipeline/hub",
@@ -218,6 +274,9 @@ Object {
     "kind": "Task",
     "latestVersion": 1,
     "name": "ansible-runner",
+    "platforms": Array [
+      1,
+    ],
     "rating": 4.5,
     "readme": "",
     "resourceKey": "tekton/Task/ansible-runner",
@@ -241,6 +300,9 @@ Object {
     "kind": "Task",
     "latestVersion": 4,
     "name": "aws-cli",
+    "platforms": Array [
+      1,
+    ],
     "rating": 5,
     "readme": "",
     "resourceKey": "tekton/Task/aws-cli",
@@ -264,6 +326,12 @@ Object {
     "kind": "Task",
     "latestVersion": 105,
     "name": "buildah",
+    "platforms": Array [
+      1,
+      4,
+      3,
+      2,
+    ],
     "rating": 4,
     "readme": "",
     "resourceKey": "tekton/Task/buildah",
@@ -287,6 +355,9 @@ Object {
     "kind": "Task",
     "latestVersion": 47,
     "name": "golang-build",
+    "platforms": Array [
+      1,
+    ],
     "rating": 5,
     "readme": "",
     "resourceKey": "tekton/Task/golang-build",
@@ -310,6 +381,9 @@ Object {
     "kind": "Task",
     "latestVersion": 104,
     "name": "jenkins",
+    "platforms": Array [
+      1,
+    ],
     "rating": 5,
     "readme": "",
     "resourceKey": "tekton/Task/jenkins",
@@ -334,6 +408,9 @@ Object {
     "kind": "Task",
     "latestVersion": 57,
     "name": "jib-maven",
+    "platforms": Array [
+      1,
+    ],
     "rating": 5,
     "readme": "",
     "resourceKey": "tekton/Task/jib-maven",
@@ -362,6 +439,10 @@ Object {
     "kind": "Pipeline",
     "latestVersion": 1,
     "name": "hub",
+    "platforms": Array [
+      1,
+      2,
+    ],
     "rating": 4.5,
     "readme": "",
     "resourceKey": "tekton-hub/Pipeline/hub",
@@ -383,6 +464,7 @@ Object {
     "kind": "Task",
     "latestVersion": 47,
     "name": "golang-build",
+    "platforms": Array [],
     "rating": 5,
     "readme": "",
     "resourceKey": "tekton-hub/Task/golang-build",
@@ -406,6 +488,9 @@ Object {
     "kind": "Task",
     "latestVersion": 1,
     "name": "ansible-runner",
+    "platforms": Array [
+      1,
+    ],
     "rating": 4.5,
     "readme": "",
     "resourceKey": "tekton/Task/ansible-runner",
@@ -429,6 +514,9 @@ Object {
     "kind": "Task",
     "latestVersion": 4,
     "name": "aws-cli",
+    "platforms": Array [
+      1,
+    ],
     "rating": 5,
     "readme": "",
     "resourceKey": "tekton/Task/aws-cli",
@@ -452,6 +540,12 @@ Object {
     "kind": "Task",
     "latestVersion": 105,
     "name": "buildah",
+    "platforms": Array [
+      1,
+      4,
+      3,
+      2,
+    ],
     "rating": 4,
     "readme": "",
     "resourceKey": "tekton/Task/buildah",
@@ -475,6 +569,9 @@ Object {
     "kind": "Task",
     "latestVersion": 47,
     "name": "golang-build",
+    "platforms": Array [
+      1,
+    ],
     "rating": 5,
     "readme": "",
     "resourceKey": "tekton/Task/golang-build",
@@ -498,6 +595,9 @@ Object {
     "kind": "Task",
     "latestVersion": 104,
     "name": "jenkins",
+    "platforms": Array [
+      1,
+    ],
     "rating": 5,
     "readme": "",
     "resourceKey": "tekton/Task/jenkins",
@@ -522,6 +622,9 @@ Object {
     "kind": "Task",
     "latestVersion": 57,
     "name": "jib-maven",
+    "platforms": Array [
+      1,
+    ],
     "rating": 5,
     "readme": "",
     "resourceKey": "tekton/Task/jib-maven",
@@ -550,6 +653,10 @@ Object {
     "kind": "Pipeline",
     "latestVersion": 1,
     "name": "hub",
+    "platforms": Array [
+      1,
+      2,
+    ],
     "rating": 4.5,
     "readme": "",
     "resourceKey": "tekton-hub/Pipeline/hub",
@@ -573,6 +680,9 @@ Object {
     "kind": "Task",
     "latestVersion": 1,
     "name": "ansible-runner",
+    "platforms": Array [
+      1,
+    ],
     "rating": 4.5,
     "readme": "",
     "resourceKey": "tekton/Task/ansible-runner",
@@ -596,6 +706,9 @@ Object {
     "kind": "Task",
     "latestVersion": 4,
     "name": "aws-cli",
+    "platforms": Array [
+      1,
+    ],
     "rating": 5,
     "readme": "",
     "resourceKey": "tekton/Task/aws-cli",
@@ -619,6 +732,12 @@ Object {
     "kind": "Task",
     "latestVersion": 105,
     "name": "buildah",
+    "platforms": Array [
+      1,
+      4,
+      3,
+      2,
+    ],
     "rating": 4,
     "readme": "",
     "resourceKey": "tekton/Task/buildah",
@@ -640,6 +759,7 @@ Object {
     "kind": "Task",
     "latestVersion": 47,
     "name": "golang-build",
+    "platforms": Array [],
     "rating": 5,
     "readme": "",
     "resourceKey": "tekton/Task/golang-build",
@@ -663,6 +783,9 @@ Object {
     "kind": "Task",
     "latestVersion": 104,
     "name": "jenkins",
+    "platforms": Array [
+      1,
+    ],
     "rating": 5,
     "readme": "",
     "resourceKey": "tekton/Task/jenkins",
@@ -687,6 +810,9 @@ Object {
     "kind": "Task",
     "latestVersion": 57,
     "name": "jib-maven",
+    "platforms": Array [
+      1,
+    ],
     "rating": 5,
     "readme": "",
     "resourceKey": "tekton/Task/jib-maven",
@@ -715,6 +841,10 @@ Object {
     "kind": "Pipeline",
     "latestVersion": 1,
     "name": "hub",
+    "platforms": Array [
+      1,
+      2,
+    ],
     "rating": 4.5,
     "readme": "",
     "resourceKey": "tekton-hub/Pipeline/hub",
@@ -738,6 +868,9 @@ Object {
     "kind": "Task",
     "latestVersion": 1,
     "name": "ansible-runner",
+    "platforms": Array [
+      1,
+    ],
     "rating": 4.5,
     "readme": "",
     "resourceKey": "tekton/Task/ansible-runner",
@@ -761,6 +894,9 @@ Object {
     "kind": "Task",
     "latestVersion": 4,
     "name": "aws-cli",
+    "platforms": Array [
+      1,
+    ],
     "rating": 5,
     "readme": "",
     "resourceKey": "tekton/Task/aws-cli",
@@ -784,6 +920,12 @@ Object {
     "kind": "Task",
     "latestVersion": 105,
     "name": "buildah",
+    "platforms": Array [
+      1,
+      4,
+      3,
+      2,
+    ],
     "rating": 4,
     "readme": "",
     "resourceKey": "tekton/Task/buildah",
@@ -807,6 +949,9 @@ Object {
     "kind": "Task",
     "latestVersion": 47,
     "name": "golang-build",
+    "platforms": Array [
+      1,
+    ],
     "rating": 5,
     "readme": "",
     "resourceKey": "tekton/Task/golang-build",
@@ -830,6 +975,9 @@ Object {
     "kind": "Task",
     "latestVersion": 104,
     "name": "jenkins",
+    "platforms": Array [
+      1,
+    ],
     "rating": 5,
     "readme": "",
     "resourceKey": "tekton/Task/jenkins",
@@ -854,6 +1002,9 @@ Object {
     "kind": "Task",
     "latestVersion": 57,
     "name": "jib-maven",
+    "platforms": Array [
+      1,
+    ],
     "rating": 5,
     "readme": "",
     "resourceKey": "tekton/Task/jib-maven",
@@ -882,6 +1033,10 @@ Object {
     "kind": "Pipeline",
     "latestVersion": 1,
     "name": "hub",
+    "platforms": Array [
+      1,
+      2,
+    ],
     "rating": 4.5,
     "readme": "",
     "resourceKey": "tekton-hub/Pipeline/hub",
@@ -905,6 +1060,9 @@ Object {
     "kind": "Task",
     "latestVersion": 1,
     "name": "ansible-runner",
+    "platforms": Array [
+      1,
+    ],
     "rating": 4.5,
     "readme": "",
     "resourceKey": "tekton/Task/ansible-runner",
@@ -928,6 +1086,9 @@ Object {
     "kind": "Task",
     "latestVersion": 4,
     "name": "aws-cli",
+    "platforms": Array [
+      1,
+    ],
     "rating": 5,
     "readme": "",
     "resourceKey": "tekton/Task/aws-cli",
@@ -951,6 +1112,12 @@ Object {
     "kind": "Task",
     "latestVersion": 105,
     "name": "buildah",
+    "platforms": Array [
+      1,
+      4,
+      3,
+      2,
+    ],
     "rating": 4,
     "readme": "",
     "resourceKey": "tekton/Task/buildah",
@@ -974,6 +1141,9 @@ Object {
     "kind": "Task",
     "latestVersion": 47,
     "name": "golang-build",
+    "platforms": Array [
+      1,
+    ],
     "rating": 5,
     "readme": "",
     "resourceKey": "tekton/Task/golang-build",
@@ -997,6 +1167,9 @@ Object {
     "kind": "Task",
     "latestVersion": 104,
     "name": "jenkins",
+    "platforms": Array [
+      1,
+    ],
     "rating": 5,
     "readme": "",
     "resourceKey": "tekton/Task/jenkins",
@@ -1021,6 +1194,9 @@ Object {
     "kind": "Task",
     "latestVersion": 57,
     "name": "jib-maven",
+    "platforms": Array [
+      1,
+    ],
     "rating": 5,
     "readme": "",
     "resourceKey": "tekton/Task/jib-maven",

--- a/ui/src/store/platform.test.ts
+++ b/ui/src/store/platform.test.ts
@@ -1,0 +1,73 @@
+import { Platform, PlatformStore } from './platform';
+import { getSnapshot } from 'mobx-state-tree';
+import { assert } from './utils';
+
+describe('Store Object', () => {
+  it('can create a platform object', () => {
+    const platform = Platform.create({
+      id: 1,
+      name: 'linux/amd64'
+    });
+
+    expect(platform.name).toBe('linux/amd64');
+  });
+
+  it('creates a platform store', (done) => {
+    const store = PlatformStore.create({});
+
+    const item = Platform.create({
+      id: 1,
+      name: 'linux/amd64'
+    });
+
+    store.add(item);
+
+    const platform = store.items.get('1');
+    assert(platform);
+
+    expect(platform.name).toBe('linux/amd64');
+    expect(getSnapshot(store.items)).toMatchSnapshot();
+
+    done();
+  });
+
+  it('should toggle a selected platform', (done) => {
+    const store = PlatformStore.create({});
+
+    const item = Platform.create({
+      id: 1,
+      name: 'linux/amd64'
+    });
+
+    store.add(item);
+
+    const platform = store.items.get('1');
+    assert(platform);
+    platform.toggle();
+
+    expect(store.selected.size).toBe(1);
+    expect(platform.selected).toBe(true);
+
+    done();
+  });
+
+  it('should clear all the selected platforms', (done) => {
+    const store = PlatformStore.create({});
+
+    const item = {
+      id: 1,
+      name: 'linux/amd64'
+    };
+
+    store.add(item);
+
+    const platform = store.items.get('1');
+    assert(platform);
+    platform.toggle();
+
+    store.clearSelected();
+    expect(platform.selected).toBe(false);
+
+    done();
+  });
+});

--- a/ui/src/store/platform.ts
+++ b/ui/src/store/platform.ts
@@ -1,0 +1,64 @@
+import { types, Instance } from 'mobx-state-tree';
+
+export const Platform = types
+  .model({
+    id: types.identifierNumber,
+    name: types.string,
+    selected: false
+  })
+
+  .actions((self) => ({
+    toggle() {
+      self.selected = !self.selected;
+    }
+  }));
+
+export type IPlatform = Instance<typeof Platform>;
+export type IPlatformStore = Instance<typeof PlatformStore>;
+
+export const PlatformStore = types
+  .model({
+    items: types.optional(types.map(Platform), {})
+  })
+
+  .actions((self) => ({
+    add(item: IPlatform): void {
+      self.items.put(item);
+    },
+
+    clearSelected() {
+      self.items.forEach((p) => {
+        p.selected = false;
+      });
+    },
+
+    toggleByName(name: string) {
+      self.items.forEach((p) => {
+        if (p.name === name) {
+          p.selected = true;
+        }
+      });
+    }
+  }))
+
+  .views((self) => ({
+    get values() {
+      return Array.from(self.items.values());
+    },
+
+    get selectedByName() {
+      return Array.from(self.items.values())
+        .filter((p: IPlatform) => p.selected)
+        .reduce((acc: string[], p: IPlatform) => [...acc, p.name], []);
+    },
+
+    get selected() {
+      const list = new Set();
+      self.items.forEach((p: IPlatform) => {
+        if (p.selected) {
+          list.add(p.id);
+        }
+      });
+      return list;
+    }
+  }));

--- a/ui/src/store/resource.test.ts
+++ b/ui/src/store/resource.test.ts
@@ -20,6 +20,7 @@ describe('Store Object', () => {
       latestVersion: 1,
       displayVersion: 1,
       tags: ['1'],
+      platforms: ['1'],
       rating: 5
     });
 
@@ -65,6 +66,27 @@ describe('Store functions', () => {
       () => {
         expect(store.resources.size).toBe(7);
         expect(getSnapshot(store.kinds)).toMatchSnapshot();
+        done();
+      }
+    );
+  });
+
+  it('creates a platform store', (done) => {
+    const store = ResourceStore.create(
+      {},
+      {
+        api,
+        categories: CategoryStore.create({}, { api })
+      }
+    );
+
+    expect(store.isLoading).toBe(true);
+
+    when(
+      () => !store.isLoading,
+      () => {
+        expect(store.resources.size).toBe(7);
+        expect(getSnapshot(store.platforms)).toMatchSnapshot();
         done();
       }
     );
@@ -155,6 +177,36 @@ describe('Store functions', () => {
 
         expect(store.filteredResources.length).toBe(2);
         expect(store.filteredResources[0].name).toBe('golang-build');
+        done();
+      }
+    );
+  });
+
+  it('filter resources based on selected platforms', (done) => {
+    const store = ResourceStore.create(
+      {},
+      {
+        api,
+        catalogs: CatalogStore.create({}, { api }),
+        categories: CategoryStore.create({}, { api })
+      }
+    );
+    expect(store.isLoading).toBe(true);
+
+    when(
+      () => !store.isLoading,
+      () => {
+        const platformA = store.platforms.items.get('2');
+        const platformB = store.platforms.items.get('3');
+
+        assert(platformA);
+        assert(platformB);
+
+        platformA.toggle();
+        platformB.toggle();
+
+        expect(store.filteredResources.length).toBe(2);
+        expect(store.filteredResources[0].name).toBe('buildah');
         done();
       }
     );

--- a/ui/src/store/testdata/resources.json
+++ b/ui/src/store/testdata/resources.json
@@ -30,6 +30,24 @@
           "name": "image-build"
         }
       ],
+      "platforms": [
+        {
+          "id": 1,
+          "name": "linux/amd64"
+        },
+        {
+          "id": 4,
+          "name": "linux/arm64"
+        },
+        {
+          "id": 3,
+          "name": "linux/ppc64le"
+        },
+        {
+          "id": 2,
+          "name": "linux/s390x"
+        }
+      ],
       "rating": 4
     },
     {
@@ -64,6 +82,12 @@
           "name": "cli"
         }
       ],
+      "platforms": [
+        {
+          "id": 1,
+          "name": "linux/amd64"
+        }
+      ],
       "rating": 5
     },
     {
@@ -95,6 +119,12 @@
         {
           "id": 1,
           "name": "build-tool"
+        }
+      ],
+      "platforms": [
+        {
+          "id": 1,
+          "name": "linux/amd64"
         }
       ],
       "rating": 5
@@ -134,6 +164,12 @@
           "name": "jenkins"
         }
       ],
+      "platforms": [
+        {
+          "id": 1,
+          "name": "linux/amd64"
+        }
+      ],
       "rating": 5
     },
     {
@@ -165,6 +201,12 @@
         {
           "id": 8,
           "name": "image-build"
+        }
+      ],
+      "platforms": [
+        {
+          "id": 1,
+          "name": "linux/amd64"
         }
       ],
       "rating": 5
@@ -200,6 +242,12 @@
           "name": "cli"
         }
       ],
+      "platforms": [
+        {
+          "id": 1,
+          "name": "linux/amd64"
+        }
+      ],
       "rating": 4.5
     },
     {
@@ -233,6 +281,12 @@
           "name": "image-build"
         }
       ],
+      "platforms": [
+        {
+          "id": 1,
+          "name": "linux/amd64"
+        }
+      ],
       "rating": 5
     },
     {
@@ -264,6 +318,16 @@
         {
           "id": 10,
           "name": "resource"
+        }
+      ],
+      "platforms": [
+        {
+          "id": 1,
+          "name": "linux/amd64"
+        },
+        {
+          "id": 2,
+          "name": "linux/s390x"
         }
       ],
       "rating": 4.5

--- a/ui/src/utils/updateUrl.test.ts
+++ b/ui/src/utils/updateUrl.test.ts
@@ -2,7 +2,9 @@ import { UpdateURL } from './updateUrl';
 
 describe('Test UpdateUrl function', () => {
   it('Test UpdateUrl function', () => {
-    const val = UpdateURL('', 'rating', 'cli', 'task', 'Tekton', ['cli', 'gke']);
-    expect(val).toEqual('sortBy=rating&category=cli&kind=task&catalog=Tekton&tag=cli&tag=gke');
+    const val = UpdateURL('', 'rating', 'cli', 'task', 'Tekton', 'linux/amd64', ['cli', 'gke']);
+    expect(val).toEqual(
+      'sortBy=rating&category=cli&platform=linux%2Famd64&kind=task&catalog=Tekton&tag=cli&tag=gke'
+    );
   });
 });

--- a/ui/src/utils/updateUrl.ts
+++ b/ui/src/utils/updateUrl.ts
@@ -9,6 +9,7 @@ export const UpdateURL = (
   categories: string,
   kinds: string,
   catalogs: string,
+  platforms: string,
   tags: Array<string>
 ) => {
   // To get URLSearchParams object instance
@@ -32,6 +33,12 @@ export const UpdateURL = (
 
   // Sets category params
   if (categories) searchParams.set(Params.Category, categories);
+
+  // To delete platform params if doesn't selected any platform
+  if (!platforms && searchParams.has(Params.Platform)) searchParams.delete(Params.Platform);
+
+  // Sets platform params
+  if (platforms) searchParams.set(Params.Platform, platforms);
 
   // To delete kind params if doesn't selected any kind
   if (!kinds && searchParams.has(Params.Kind)) searchParams.delete(Params.Kind);


### PR DESCRIPTION
# Changes

Hub resources have information about platforms they can run on. It makes sense to let user to filter the resources based on the platforms. This patch provides this option based on platforms information on resource level and
- creates store for platforms
- injects platforms into resource store
- adds PlatformFilter for the left pane
- extends updateUrl logic with platform parameter

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [x] Run API Unit Tests, Lint Checks, API Design, Golden Files with `make api-check`
- [x] Run UI Unit Tests, Lint Checks with `make ui-check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._
