### PR TITLE
Bump base images in API and UI Dockerfiles

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.15-alpine3.12 AS builder
+FROM golang:1.15-alpine3.14 AS builder
 
 WORKDIR /go/src/github.com/tektoncd/hub/api
 COPY . .
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o api-server ./cmd/api/...
 
-FROM alpine:3.12
+FROM alpine:3.14
 
 RUN apk --no-cache add git ca-certificates && addgroup -S hub && adduser -S hub -G hub
 USER hub

--- a/api/db.Dockerfile
+++ b/api/db.Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.15-alpine3.12 AS builder
+FROM golang:1.15-alpine3.14 AS builder
 
 WORKDIR /go/src/github.com/tektoncd/hub/api
 COPY . .
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o db-migration ./cmd/db/...
 
-FROM alpine:3.12
+FROM alpine:3.14
 
 RUN apk --no-cache add ca-certificates && addgroup -S hub && adduser -S hub -G hub
 USER hub

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-alpine as BUILD
+FROM node:16-alpine3.14 as BUILD
 WORKDIR /app
 
 # install deps and the copy the src to speed up docker build


### PR DESCRIPTION
# Changes

UI is now using node 16 so bumping the node version in Dockerfile.
Also bumping base images of API and DB-migration to use alpine:3.14.

Signed-off-by: vinamra28 <vinjain@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Run API Unit Tests, Lint Checks, API Design, Golden Files with `make api-check`
- [ ] Run UI Unit Tests, Lint Checks with `make ui-check`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._
