### PR TITLE
Adds a script to generate release yamls

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+
+# Copyright © 2022 The Tekton Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+RELEASE_VERSION=""
+
+declare -r SCRIPT_PATH=$(readlink -f "$0")
+declare -r SCRIPT_DIR=$(cd $(dirname "$SCRIPT_PATH") && pwd)
+declare -r API_DIR="$SCRIPT_DIR/api"
+declare -r UI_DIR="$SCRIPT_DIR/ui"
+declare -r RELEASE_DIR="$SCRIPT_DIR/release"
+DOCKER_CMD=${DOCKER_CMD:-docker}
+REGISTRY_BASE_URL=${REGISTRY_BASE_URL:-quay.io/tekton-hub}
+
+BINARIES="ko hub"
+
+info() {
+  echo "INFO: $@"
+}
+
+err() {
+  echo "ERROR: $@"
+}
+
+getReleaseVersion() {
+  [[ -z ${RELEASE_VERSION} ]] && {
+    read -r -e -p "Enter a target release (i.e: v0.1.2): " RELEASE_VERSION
+    [[ -z ${RELEASE_VERSION} ]] && {
+      echo "no target release"
+      exit 1
+    }
+  }
+  [[ ${RELEASE_VERSION} =~ v[0-9]+\.[0-9]*\.[0-9]+ ]] || {
+    echo "invalid version provided, need to match v\d+\.\d+\.\d+"
+    exit 1
+  }
+}
+
+buildDbMigrationImage() {
+  info Building DB Migration Image
+  echo -----------------------------------
+  cd "$API_DIR"
+  ${DOCKER_CMD} build -f db.Dockerfile -t ${REGISTRY_BASE_URL}/db-migration:${RELEASE_VERSION} . && ${DOCKER_CMD} push ${REGISTRY_BASE_URL}/db-migration:${RELEASE_VERSION}
+  info DB Migration Image Build Successfully
+  echo -----------------------------------
+}
+
+buildApiImage() {
+  info Building API Image
+  echo -----------------------------------
+  cd "$API_DIR"
+  ${DOCKER_CMD} build -t ${REGISTRY_BASE_URL}/api:${RELEASE_VERSION} . && ${DOCKER_CMD} push ${REGISTRY_BASE_URL}/api:${RELEASE_VERSION}
+  info API Image Build Successfully
+  echo -----------------------------------
+}
+
+buildUiImage() {
+  info Building UI Image
+  echo -----------------------------------
+  cd "$UI_DIR"
+  ${DOCKER_CMD} build -t ${REGISTRY_BASE_URL}/ui:${RELEASE_VERSION} . && ${DOCKER_CMD} push ${REGISTRY_BASE_URL}/ui:${RELEASE_VERSION}
+  info UI Image Build Successfully
+  echo -----------------------------------
+}
+
+db(){
+	info Creating DB Release Yaml
+
+  ko resolve -f 00-init  > "${RELEASE_DIR}"/db.yaml || {
+    err 'db release build failed'
+    return 1
+  }
+  echo "-----------------------------------------"
+}
+
+db-migration(){
+	info Creating Db-Migration Release Yaml
+
+  ko resolve -f 01-db  > "${RELEASE_DIR}"/db-migration.yaml || {
+    err 'db-migration release build failed'
+    return 1
+  }
+  echo "------------------------------------------"
+}
+
+api-k8s(){
+	info Creating API Release Yaml
+
+  ko resolve -f 02-api  > "${RELEASE_DIR}"/api-k8s.yaml || {
+    err 'api release build failed'
+    return 1
+  }
+  echo "------------------------------------------"
+}
+
+api-openshift(){
+	info Creating API Release Yaml
+
+  ko resolve -f 02-api -f 04-openshift/40-api-route.yaml > "${RELEASE_DIR}"/api-openshift.yaml || {
+    err 'api release build failed'
+    return 1
+  }
+  echo "------------------------------------------"
+}
+
+ui-k8s(){
+	info Creating UI Release Yaml
+
+  ko resolve -f 03-ui > "${RELEASE_DIR}"/ui-k8s.yaml || {
+    err 'ui release build failed'
+    return 1
+  }
+  echo "------------------------------------------"
+}
+
+ui-openshift(){
+	info Creating UI Release Yaml
+
+  ko resolve -f 03-ui -f 04-openshift/41-ui-route.yaml > "${RELEASE_DIR}"/ui-openshift.yaml || {
+    err 'ui release build failed'
+    return 1
+  }
+  echo "------------------------------------------"
+}
+
+replaceImageName() {
+  info Changing Image Name
+
+  cd ${RELEASE_DIR}
+  #  Replace the db-migration image name
+  sed -i "s@image: quay.io/tekton-hub/db-migration@image: ${REGISTRY_BASE_URL}/db-migration:$RELEASE_VERSION@g" ${RELEASE_DIR}/db-migration.yaml
+
+  # Replace the api image
+  sed -i "s@image: quay.io/tekton-hub/api@image: ${REGISTRY_BASE_URL}/api:$RELEASE_VERSION@g" ${RELEASE_DIR}/api-k8s.yaml
+
+  sed -i "s@image: quay.io/tekton-hub/api@image: ${REGISTRY_BASE_URL}/api:$RELEASE_VERSION@g" ${RELEASE_DIR}/api-openshift.yaml
+
+  #Replace the ui image
+  sed -i "s@image: quay.io/tekton-hub/ui@image: ${REGISTRY_BASE_URL}/ui:$RELEASE_VERSION@g" ${RELEASE_DIR}/ui-k8s.yaml
+
+  sed -i "s@image: quay.io/tekton-hub/ui@image: ${REGISTRY_BASE_URL}/ui:$RELEASE_VERSION@g" ${RELEASE_DIR}/ui-openshift.yaml
+}
+
+createGitTag() {
+  echo; echo 'Creating tag for new release:'
+
+  hub release create --draft --prerelease -a db.yaml \
+   -a db-migration.yaml \
+   -a  api-k8s.yaml \
+   -a api-openshift.yaml \
+   -a  ui-k8s.yaml \
+   -a ui-openshift.yaml \
+   -m "${RELEASE_VERSION}" "${RELEASE_VERSION}"
+}
+
+main() {
+
+  # Check if all required command exists
+  for b in ${BINARIES};do
+      type -p ${b} >/dev/null || { echo "'${b}' need to be avail"; exit 1 ;}
+  done
+
+  # Ask the release version to build images
+  getReleaseVersion
+
+  # Generate the release yamls for db, db-migration, api and ui
+  echo "********************************************"
+  info     Generate the Release Yamls for Hub
+  echo "********************************************"
+  cd config
+  db
+  db-migration
+  api-k8s
+  api-openshift
+  ui-k8s
+  ui-openshift
+
+  # Build images for db-migration, api and ui
+  echo "********************************************"
+  info        Build the Images for Hub
+  echo "********************************************"
+  buildDbMigrationImage
+  buildApiImage
+  buildUiImage
+
+  # Change the image name with the release version specified
+  echo "********************************************"
+  info      Replace the Images with New Version
+  echo "********************************************"
+  replaceImageName
+
+  echo "********************************************"
+  info            Create Git Tag
+  echo "********************************************"
+  createGitTag
+
+  echo "********************************************"
+  echo "***" Release Created for Hub successfully "***"
+  echo "********************************************"
+}
+
+main $@

--- a/release/RELEASE.md
+++ b/release/RELEASE.md
@@ -1,0 +1,41 @@
+# Release
+
+- [Prerequisites](#prerequisites)
+- [Implementation](implementation)
+
+## Prerequisites
+
+- [ko][ko]
+- [docker][docker] or [podman][podman]
+- [hub][hub]
+
+## Implementation
+
+1. Once the above tools are installed, run the `release.sh` script which generates the release yamls for `db-migration`, `api` and `ui`
+
+   ```
+   REGISTRY_BASE_URL=docker.io/<username> bash release.sh
+   ```
+
+   **NOTE**: By default the registry is `quay.io/tekton-hub` and docker is by default tool to build the images. If you have `podman` you can run the command as
+
+   ```
+   DOCKER_CMD=podman REGISTRY_BASE_URL=docker.io/<username> bash release.sh
+   ```
+
+   - This will generate the following release yamls using ko
+     - db-migration
+     - api-k8s
+     - api-openshift
+     - ui-k8s
+     - ui-openshift
+   - Build the images for db-migration, api and ui and pushes the images to the specified registry
+   - Replaces the generated yamls with the newly build images
+   - Creates a draft release and attaches the generated release yamls
+
+2. Once the release yamls are attached to the draft release then edit the draft release by adding the release notes for the release and publish the release
+
+[ko]: https://github.com/google/ko
+[docker]: https://docs.docker.com/engine/install/
+[podman]: https://podman.io/getting-started/installation
+[hub]: https://github.com/github/hub#installation


### PR DESCRIPTION
  - This patch adds a bash script which creates the
    rerlease yamls for

     - db
     - db-migration
     - api-k8s (specific to kubernetes)
     - api-openshift (specific to openshift i.e. adds routes)
     - ui-k8s (specific to kubernetes)
     - ui-openshift (specific to openshift i.e. adds routes)

  - Creates a preview release with all the generated release yamls attached
         to the assets
    
 - Adds a RELEASE.md which defines the steps to create a release for hub

Signed-off-by: Puneet Punamiya <ppunamiy@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [x] Run API Unit Tests, Lint Checks, API Design, Golden Files with `make api-check`
- [x] Run UI Unit Tests, Lint Checks with `make ui-check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._
