### PR TITLE
Use Postgres container image provided by Red Hat

### DIFF
--- a/config/00-init/01-db-secret.yaml
+++ b/config/00-init/01-db-secret.yaml
@@ -21,6 +21,6 @@ metadata:
 type: Opaque
 stringData:
   POSTGRES_DB: hub
-  POSTGRES_USER: postgres
-  POSTGRES_PASSWORD: postgres
+  POSTGRES_USER: hub
+  POSTGRES_PASSWORD: hub
   POSTGRES_PORT: "5432"

--- a/config/00-init/03-db-deployment.yaml
+++ b/config/00-init/03-db-deployment.yaml
@@ -30,41 +30,39 @@ spec:
     spec:
       containers:
         - name: db
-          image: postgres:13@sha256:260a98d976574b439712c35914fdcb840755233f79f3e27ea632543f78b7a21e
+          image: registry.redhat.io/rhel8/postgresql-13:1-18
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 5432
               protocol: TCP
           env:
-            - name: POSTGRES_DB
+            - name: POSTGRESQL_DATABASE
               valueFrom:
                 secretKeyRef:
                   name: db
                   key: POSTGRES_DB
-            - name: POSTGRES_USER
+            - name: POSTGRESQL_USER
               valueFrom:
                 secretKeyRef:
                   name: db
                   key: POSTGRES_USER
-            - name: POSTGRES_PASSWORD
+            - name: POSTGRESQL_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: db
                   key: POSTGRES_PASSWORD
-            - name: PGDATA
-              value: /var/lib/postgresql/data/pgdata
           volumeMounts:
             - name: db
-              mountPath: /var/lib/postgresql/data
+              mountPath: /var/lib/pgsql/data
           readinessProbe:
             exec:
-              command: [bash, -c, "psql -w -U ${POSTGRES_USER} -d ${POSTGRES_DB} -c 'SELECT 1'"]
+              command: [bash, -c, "psql -w -U ${POSTGRESQL_USER} -d ${POSTGRESQL_DATABASE} -c 'SELECT 1'"]
             initialDelaySeconds: 15
             timeoutSeconds: 2
             periodSeconds: 15
           livenessProbe:
             exec:
-              command: [bash, -c, "psql -w -U ${POSTGRES_USER} -d ${POSTGRES_DB} -c 'SELECT 1'"]
+              command: [bash, -c, "psql -w -U ${POSTGRESQL_USER} -d ${POSTGRESQL_DATABASE} -c 'SELECT 1'"]
             initialDelaySeconds: 45
             timeoutSeconds: 2
             periodSeconds: 15


### PR DESCRIPTION
# Changes

Currently we are using the image from DockerHub which may not reliable
for the the customers who are running hub on openshift. This patch
switches the image from the dockerhub one to the one which is provided
by Red Hat. The following change requires some modifications in the spec
of Deployment as well as the value of secrets needs to be changed.

Signed-off-by: vinamra28 <vinjain@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Run API Unit Tests, Lint Checks, API Design, Golden Files with `make api-check`
- [ ] Run UI Unit Tests, Lint Checks with `make ui-check`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._
