### PR TITLE
Minor fixes in API and UI and Config files updates

### DIFF
--- a/api/pkg/auth/base.go
+++ b/api/pkg/auth/base.go
@@ -65,7 +65,7 @@ func AuthProvider(r *mux.Router, api app.Config) {
 			githubAuth.TokenUrl,
 			githubAuth.ProfileUrl,
 			githubAuth.EmailUrl,
-			"user"),
+			"user:email"),
 
 		gitlab.NewCustomisedURL(
 			gitlabAuth.ClientId,
@@ -74,12 +74,14 @@ func AuthProvider(r *mux.Router, api app.Config) {
 			gitlabAuth.AuthUrl,
 			gitlabAuth.TokenUrl,
 			gitlabAuth.ProfileUrl,
+			"read_user",
 		),
 
 		bitbucket.New(
 			bitbucketAuth.ClientId,
 			bitbucketAuth.ClientSecret,
 			bitbucketAuth.CallbackUrl,
+			"email",
 		),
 	)
 

--- a/api/pkg/db/migration/202111091037_backup_users_add_account_table_and_update_data.go
+++ b/api/pkg/db/migration/202111091037_backup_users_add_account_table_and_update_data.go
@@ -74,6 +74,8 @@ func addUsersDetailsInAccountTable(log *log.Logger) *gormigrate.Migration {
 					UserID:   user.ID,
 					UserName: user.GithubLogin,
 					Name:     user.GithubName,
+					// Assumption taken over here is that all the existing users were from github
+					Provider: "github",
 				}
 				accounts = append(accounts, account)
 			}

--- a/api/pkg/service/admin/admin.go
+++ b/api/pkg/service/admin/admin.go
@@ -121,6 +121,15 @@ func (r *agentRequest) addNewAgent(name string, scopes []string) (string, error)
 		AgentName: name,
 		Type:      model.AgentUserType,
 	}
+
+	// User ID is by default set to zero so we need to update the value with (last inserted user_id+1)
+	lastUser := model.User{}
+	if err := r.db.Model(&model.User{}).Last(&lastUser).Error; err != nil {
+		r.log.Error(err)
+		return "", err
+	}
+	agent.ID = lastUser.ID + 1
+
 	if err := r.db.Create(&agent).Error; err != nil {
 		r.log.Error(err)
 		return "", internalError

--- a/config/02-api/22-api-deployment.yaml
+++ b/config/02-api/22-api-deployment.yaml
@@ -33,6 +33,7 @@ spec:
           image: quay.io/tekton-hub/api
           ports:
             - containerPort: 8000
+            - containerPort: 4200
           readinessProbe:
             failureThreshold: 3
             httpGet:
@@ -103,12 +104,12 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: api
-                  key: GH_CLIENT_SECRET
+                  key: GL_CLIENT_SECRET
             - name: GLE_URL
               valueFrom:
                 secretKeyRef:
                   name: api
-                  key: GHE_URL
+                  key: GLE_URL
             - name: BB_CLIENT_ID
               valueFrom:
                 secretKeyRef:

--- a/config/02-api/23-api-service.yaml
+++ b/config/02-api/23-api-service.yaml
@@ -23,6 +23,10 @@ spec:
   selector:
     app: api
   ports:
-    - port: 8000
+    - name: api
+      port: 8000
       targetPort: 8000
+    - name: oauth
+      port: 4200
+      targetPort: 4200
   type: NodePort

--- a/config/04-kubernetes/40-oauth-ingress.yaml
+++ b/config/04-kubernetes/40-oauth-ingress.yaml
@@ -1,0 +1,19 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    acme.cert-manager.io/http01-edit-in-place: 'true'
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  name: oauth
+spec:
+  rules:
+  - http:
+      paths:
+      - backend:
+          serviceName: api
+          servicePort: 4200
+        path: /*
+  tls:
+  - hosts:
+    - oauth.hub.tekton.dev
+    secretName: oauth-hub-tekton-dev-tls

--- a/config/04-openshift/40-oauth-route.yaml
+++ b/config/04-openshift/40-oauth-route.yaml
@@ -1,4 +1,4 @@
-# Copyright © 2020 The Tekton Authors.
+# Copyright © 2022 The Tekton Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,12 +15,12 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  name: api
+  name: oauth
   labels:
     app: api
 spec:
   port:
-    targetPort: 8000
+    targetPort: 4200
   to:
     kind: Service
     name: api

--- a/config/05-catalog-refresh-cj/51-catalog-refresh-cronjob.yaml
+++ b/config/05-catalog-refresh-cj/51-catalog-refresh-cronjob.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: catalog-refresh

--- a/release.sh
+++ b/release.sh
@@ -108,7 +108,7 @@ api-k8s(){
 api-openshift(){
 	info Creating API Release Yaml
 
-  ko resolve -f 02-api -f 04-openshift/40-api-route.yaml > "${RELEASE_DIR}"/api-openshift.yaml || {
+  ko resolve -f 02-api -f 04-openshift/40-api-route.yaml -f 04-openshift/40-oauth-route.yaml > "${RELEASE_DIR}"/api-openshift.yaml || {
     err 'api release build failed'
     return 1
   }

--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -53,7 +53,7 @@ export class Hub implements Api {
 
   async resources() {
     try {
-      return axios.get(`${API_URL}/resources`).then((response) => response.data);
+      return axios.get(`${API_URL}/${API_VERSION}/resources`).then((response) => response.data);
     } catch (err) {
       return err.response;
     }
@@ -81,7 +81,7 @@ export class Hub implements Api {
   async resourceVersion(resourceId: number) {
     try {
       return axios
-        .get(`${API_URL}/resource/${resourceId}/versions`)
+        .get(`${API_URL}/${API_VERSION}/resource/${resourceId}/versions`)
         .then((response) => response.data);
     } catch (err) {
       return err.response;
@@ -91,7 +91,7 @@ export class Hub implements Api {
   async versionUpdate(versionId: number) {
     try {
       return axios
-        .get(`${API_URL}/resource/version/${versionId}`)
+        .get(`${API_URL}/${API_VERSION}/resource/version/${versionId}`)
         .then((response) => response.data);
     } catch (err) {
       return err.response;

--- a/ui/src/containers/ParseUrl/index.tsx
+++ b/ui/src/containers/ParseUrl/index.tsx
@@ -19,10 +19,12 @@ const ParseUrl: React.FC = () => {
         code: code
       };
       user.authenticate(codeFinal);
-      history.goBack();
+      if (user.isAuthenticated) {
+        history.goBack();
+      }
     }
     // Display the alert message when status is not ok
-    if (status !== '200' || code === null) {
+    else if (status !== '200' || code === null) {
       // Wait to redirection of page and then update the store
       setTimeout(() => {
         const error: IError = {


### PR DESCRIPTION
# Changes

## API
- Instead of asking users to grant scope to read/write their data, we
  are just asking the email read permission.
- While applying the db-migration, assumption is taken that all the
  previous users were from `github` as other providers were not
  supported earlier.
- User agent was not getting created due to duplicate key violation, so
  handled that.
## UI
- Use `/v1/resources` API instead of `/resources` as they are now
  deprecated.
- `history.goBack()` was getting executed even if user was not getting
  authenticated, added a condition to check if user's authentication is
  successful then only execute it.

## Configs
- Expose oauth containerPort from deployment
- Update service to expose the oauth port
- Add Route and Ingress for Oauth server
- Use `batch/v1` CronJob instead of `batch/v1beta1` as it's deprecated
- Update release script to include oauth server route
- ENVs for Gitlab were wrongly mapped with Github secret keys, fixed that
    
Signed-off-by: vinamra28 <vinjain@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Run API Unit Tests, Lint Checks, API Design, Golden Files with `make api-check`
- [ ] Run UI Unit Tests, Lint Checks with `make ui-check`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._
