### PR TITLE
Add annotations in ingress for API and Auth and rename oauth to auth

### DIFF
--- a/config/02-api/23-api-service.yaml
+++ b/config/02-api/23-api-service.yaml
@@ -26,7 +26,7 @@ spec:
     - name: api
       port: 8000
       targetPort: 8000
-    - name: oauth
+    - name: auth
       port: 4200
       targetPort: 4200
   type: NodePort

--- a/config/04-kubernetes/40-api-ingress.yaml
+++ b/config/04-kubernetes/40-api-ingress.yaml
@@ -4,10 +4,13 @@ metadata:
   annotations:
     acme.cert-manager.io/http01-edit-in-place: 'true'
     cert-manager.io/cluster-issuer: letsencrypt-prod
+    dns.gardener.cloud/dnsnames: 'api.hub.tekton.dev'
+    dns.gardener.cloud/ttl: "3600"
   name: api
 spec:
   rules:
-  - http:
+  - host: api.hub.tekton.dev
+    http:
       paths:
       - backend:
           serviceName: api

--- a/config/04-kubernetes/40-auth-ingress.yaml
+++ b/config/04-kubernetes/40-auth-ingress.yaml
@@ -4,10 +4,13 @@ metadata:
   annotations:
     acme.cert-manager.io/http01-edit-in-place: 'true'
     cert-manager.io/cluster-issuer: letsencrypt-prod
-  name: oauth
+    dns.gardener.cloud/dnsnames: 'auth.hub.tekton.dev'
+    dns.gardener.cloud/ttl: "3600"
+  name: auth
 spec:
   rules:
-  - http:
+  - host: auth.hub.tekton.dev
+    http:
       paths:
       - backend:
           serviceName: api
@@ -15,5 +18,5 @@ spec:
         path: /*
   tls:
   - hosts:
-    - oauth.hub.tekton.dev
-    secretName: oauth-hub-tekton-dev-tls
+    - auth.hub.tekton.dev
+    secretName: auth-hub-tekton-dev-tls

--- a/config/04-openshift/40-auth-route.yaml
+++ b/config/04-openshift/40-auth-route.yaml
@@ -15,7 +15,7 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  name: oauth
+  name: auth
   labels:
     app: api
 spec:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -140,7 +140,7 @@ db-migration-8vhpd     0/1     Error       0          17s
 - If deploying on OpenShift:-
 
   ```bash
-  kubectl apply -f 04-openshift/40-api-route.yaml -f 04-openshift/40-oauth-route.yaml -n tekton-hub
+  kubectl apply -f 04-openshift/40-api-route.yaml -f 04-openshift/40-auth-route.yaml -n tekton-hub
   ```
 
 - If deploying on Kubernetes:-
@@ -154,7 +154,7 @@ db-migration-8vhpd     0/1     Error       0          17s
     - Apply the Ingress
 
       ```bash
-      kubectl apply -f 04-kubernetes/40-api-ingress.yaml -f 04-kubernetes/40-oauth-ingress.yaml -n tekton-hub
+      kubectl apply -f 04-kubernetes/40-api-ingress.yaml -f 04-kubernetes/40-auth-ingress.yaml -n tekton-hub
       ```
 
 ### Create Git Oauth Applications

--- a/release.sh
+++ b/release.sh
@@ -108,7 +108,7 @@ api-k8s(){
 api-openshift(){
 	info Creating API Release Yaml
 
-  ko resolve -f 02-api -f 04-openshift/40-api-route.yaml -f 04-openshift/40-oauth-route.yaml > "${RELEASE_DIR}"/api-openshift.yaml || {
+  ko resolve -f 02-api -f 04-openshift/40-api-route.yaml -f 04-openshift/40-auth-route.yaml > "${RELEASE_DIR}"/api-openshift.yaml || {
     err 'api release build failed'
     return 1
   }


### PR DESCRIPTION
# Changes

In order to deploy Hub and related components on Tekton dogfooding
cluster, we need to add some annotations which can generate tls certs
and dns records. This patch contains those annotations. Also renaming
`oauth` to `auth`.

Signed-off-by: vinamra28 <vinjain@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Run API Unit Tests, Lint Checks, API Design, Golden Files with `make api-check`
- [ ] Run UI Unit Tests, Lint Checks with `make ui-check`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._
