### PR TITLE
Fix Generation of Raw Readme and YAMLs in v1 APIs

### DIFF
--- a/api/v1/service/resource/resource.go
+++ b/api/v1/service/resource/resource.go
@@ -31,12 +31,12 @@ type service struct {
 	app.Service
 }
 
-var replacerStrings = []string{"github.com", "raw.githubusercontent.com", "/tree/", "/"}
+var replacerStrings = []string{"github.com", "raw.githubusercontent.com", "/tree/", "/", "/blob/", "/raw/", "/src/", "/raw/"}
 
 // Returns a replacer object which replaces a list of strings with replacements.
 // This function basically helps create the raw URL
-func getStringReplacer(resourceUrl string) *strings.Replacer {
-	if !strings.HasPrefix(resourceUrl, "https://github.com") {
+func getStringReplacer(resourceUrl, provider string) *strings.Replacer {
+	if !strings.HasPrefix(resourceUrl, "https://github.com") && provider == "github" {
 		parsedUrl, _ := url.Parse(resourceUrl)
 		host := "raw." + parsedUrl.Host
 		replacerStrings = append(replacerStrings, parsedUrl.Host, host)
@@ -305,7 +305,7 @@ func initResource(r model.Resource) *resource.ResourceData {
 		DisplayName:         lv.DisplayName,
 		MinPipelinesVersion: lv.MinPipelinesVersion,
 		WebURL:              lv.URL,
-		RawURL:              getStringReplacer(lv.URL).Replace(lv.URL),
+		RawURL:              getStringReplacer(lv.URL, r.Catalog.Provider).Replace(lv.URL),
 		HubURLPath:          fmt.Sprintf("%s/%s/%s/%s", r.Catalog.Name, r.Kind, r.Name, lv.Version),
 		UpdatedAt:           lv.ModifiedAt.UTC().Format(time.RFC3339),
 		Platforms:           platforms,
@@ -361,7 +361,7 @@ func minVersionInfo(r model.ResourceVersion) *resource.ResourceVersionData {
 
 	res := tinyVersionInfo(r)
 	res.WebURL = r.URL
-	res.RawURL = getStringReplacer(r.URL).Replace(r.URL)
+	res.RawURL = getStringReplacer(r.URL, r.Resource.Catalog.Provider).Replace(r.URL)
 	platforms := []*resource.Platform{}
 	for _, platform := range r.Platforms {
 		platforms = append(platforms, &resource.Platform{
@@ -433,7 +433,7 @@ func versionInfoFromResource(r model.Resource, version string) *resource.Resourc
 		DisplayName:         v.DisplayName,
 		MinPipelinesVersion: v.MinPipelinesVersion,
 		WebURL:              v.URL,
-		RawURL:              getStringReplacer(v.URL).Replace(v.URL),
+		RawURL:              getStringReplacer(v.URL, r.Catalog.Provider).Replace(v.URL),
 		HubURLPath:          fmt.Sprintf("%s/%s/%s/%s", r.Catalog.Name, r.Kind, r.Name, v.Version),
 		UpdatedAt:           v.ModifiedAt.UTC().Format(time.RFC3339),
 		Resource:            res,

--- a/api/v1/service/resource/resource_test.go
+++ b/api/v1/service/resource/resource_test.go
@@ -242,7 +242,7 @@ func TestByID_NotFoundError(t *testing.T) {
 
 func TestCreationRawURL(t *testing.T) {
 	url := "https://ghe.myhost.com/org/repo/tree/main/task/name/0.1/name.yaml"
-	replacer := getStringReplacer(url)
+	replacer := getStringReplacer(url, "github")
 	rawUrl := replacer.Replace(url)
 	expected := "https://raw.ghe.myhost.com/org/repo/main/task/name/0.1/name.yaml"
 	assert.Equal(t, expected, rawUrl)
@@ -269,4 +269,28 @@ func TestLatestVersionDeprecationByID(t *testing.T) {
 	res, err := resourceSvc.ByID(context.Background(), payload)
 	assert.NoError(t, err)
 	assert.Equal(t, true, *res.Data.LatestVersion.Deprecated)
+}
+
+func TestCreationRawURLBitbucket(t *testing.T) {
+	url := "https://bitbucket.org/org/catalog/src/main/task/name/0.1/name.yaml"
+	replacer := getStringReplacer(url, "bitbucket")
+	rawUrl := replacer.Replace(url)
+	expected := "https://bitbucket.org/org/catalog/raw/main/task/name/0.1/name.yaml"
+	assert.Equal(t, expected, rawUrl)
+}
+
+func TestCreationRawURLGitlab(t *testing.T) {
+	url := "https://gitlab.com/org/catalog/-/blob/main/task/name/0.1/name.yaml"
+	replacer := getStringReplacer(url, "gitlab")
+	rawUrl := replacer.Replace(url)
+	expected := "https://gitlab.com/org/catalog/-/raw/main/task/name/0.1/name.yaml"
+	assert.Equal(t, expected, rawUrl)
+}
+
+func TestCreationRawURLGitlabEnterprise(t *testing.T) {
+	url := "https://gitlab.myhost.com/org/catalog/-/blob/main/task/name/0.1/name.yaml"
+	replacer := getStringReplacer(url, "gitlab")
+	rawUrl := replacer.Replace(url)
+	expected := "https://gitlab.myhost.com/org/catalog/-/raw/main/task/name/0.1/name.yaml"
+	assert.Equal(t, expected, rawUrl)
 }


### PR DESCRIPTION
# Changes

With reference to PR #321, the changed made to support catalog refresh
from different providers were missed to be updated in v1 APIs. This
patch fixes the generation of raw YAMLs when the resource is from
different git providers such as bitbucket or gitlab.

Signed-off-by: vinamra28 <vinjain@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [X] Run API Unit Tests, Lint Checks, API Design, Golden Files with `make api-check`
- [X] Run UI Unit Tests, Lint Checks with `make ui-check`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._
