### PR TITLE
Store the cloned catalog in persistent storage

### DIFF
--- a/config/02-api/20-api-pvc.yaml
+++ b/config/02-api/20-api-pvc.yaml
@@ -1,0 +1,26 @@
+# Copyright © 2022 The Tekton Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: api
+  labels:
+    app: api
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/config/02-api/22-api-deployment.yaml
+++ b/config/02-api/22-api-deployment.yaml
@@ -28,9 +28,22 @@ spec:
       labels:
         app: api
     spec:
+      volumes:
+      - name: catalog-source
+        persistentVolumeClaim:
+          claimName: api
+      - name: ssh-creds
+        secret:
+          secretName: tekton-hub-api-ssh-crds
+          optional: true
       containers:
         - name: api
           image: quay.io/tekton-hub/api
+          volumeMounts:
+          - name: catalog-source
+            mountPath: "/tmp"
+          - name: ssh-creds
+            mountPath: "/home/hub/.ssh"
           ports:
             - containerPort: 8000
             - containerPort: 4200
@@ -53,6 +66,8 @@ spec:
             successThreshold: 1
             timeoutSeconds: 1
           env:
+            - name: HOME
+              value: /home/hub
             - name: POSTGRES_HOST
               value: db
             - name: POSTGRES_PORT

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -233,6 +233,19 @@ All users have default scopes `rating:read` and `rating:write`. Once user get lo
 
 **WARN** : Make sure you have updated Hub config before starting the api server
 
+### Create SSH secrets (Optional)
+
+In order to clone private repositories or repositories from private git instances,
+we need to mount the ssh credentials so that cloning can happen. To make this happen
+please follow the below steps:
+
+1. Create the ssh keys if not already present in `~/.ssh` dir.
+1. Create kubernetes secret which will contain the ssh keys using the following command
+    ```sh
+    kubectl create secret generic tekton-hub-api-ssh-crds --from-file=id_rsa="/path/to/id_rsa" --from-file=id_rsa.pub="/path/to/id_rsa.pub" --from-file=known_hosts="/path/to/known_hosts"
+    ```
+  Please make sure that secrets are created with the name `tekton-hub-api-ssh-crds`
+
 ### Update API Image
 
 Edit the `02-api/22-api-deployment.yaml` and replace the image with the one created previously and executed below command

--- a/images/db.Dockerfile
+++ b/images/db.Dockerfile
@@ -11,7 +11,7 @@ RUN apk --no-cache add ca-certificates && addgroup -S hub && adduser -S hub -G h
 USER hub
 
 WORKDIR /app
-COPY --from=builder /go/src/github.com/tektoncd/hub/api/db-migration /app/db-migration
+COPY --from=builder /go/src/github.com/tektoncd/hub/db-migration /app/db-migration
 EXPOSE 8000
 
 CMD [ "/app/db-migration" ]

--- a/images/ui.Dockerfile
+++ b/images/ui.Dockerfile
@@ -13,7 +13,7 @@ RUN npm run build
 # Stage 2 - the production environment
 FROM nginxinc/nginx-unprivileged
 COPY --from=BUILD /app/build /usr/share/nginx/html
-COPY image/start.sh /usr/bin/
+COPY ui/image/start.sh /usr/bin/
 
 USER root
 RUN chmod ugo+rw /usr/share/nginx/html/config.js  && \
@@ -23,6 +23,6 @@ USER nginx
 
 EXPOSE 8080
 
-COPY image/nginx.conf /etc/nginx/conf.d/default.conf
+COPY ui/image/nginx.conf /etc/nginx/conf.d/default.conf
 
 CMD /usr/bin/start.sh


### PR DESCRIPTION
# Changes

Since we will now be reading the catalog manifests from the cloned
catalog directly instead of relying on git providers, we need to keep
that catalog in persistent storage so that even if the pod is deleted,
data isn't deleted. This patch Adds a PVC which will be used to store
the cloned catalog after a catalog refresh is done. Also updating the
deployment manifest to mount that pvc in `/tmp` directly where we are
actually cloning the catalogs.

Signed-off-by: vinamra28 <vinjain@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Run API Unit Tests, Lint Checks, API Design, Golden Files with `make api-check`
- [ ] Run UI Unit Tests, Lint Checks with `make ui-check`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._
