### PR TITLE
Update `get` command to use the latest API

### DIFF
--- a/api/pkg/cli/cmd/get/get.go
+++ b/api/pkg/cli/cmd/get/get.go
@@ -106,15 +106,20 @@ func (opts *options) run() error {
 		return err
 	}
 
-	resource := opts.hubClient.GetResource(hub.ResourceOption{
+	resource := opts.hubClient.GetResourceYaml(hub.ResourceOption{
 		Name:    name,
 		Catalog: opts.from,
 		Kind:    opts.kind,
 		Version: opts.version,
 	})
 
+	data, err := resource.ResourceYaml()
+	if err != nil {
+		return err
+	}
+
 	out := opts.cli.Stream().Out
-	return printer.New(out).Raw(resource.Manifest())
+	return printer.New(out).RawYaml(data, nil)
 }
 
 func (opts *options) validate() error {

--- a/api/pkg/cli/cmd/get/task.go
+++ b/api/pkg/cli/cmd/get/task.go
@@ -15,7 +15,7 @@
 package get
 
 import (
-	"bytes"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/hub/api/pkg/cli/hub"
@@ -66,14 +66,14 @@ func (opts *taskOptions) run() error {
 		return err
 	}
 
-	resource := opts.hubClient.GetResource(hub.ResourceOption{
+	resource := opts.hubClient.GetResourceYaml(hub.ResourceOption{
 		Name:    name,
 		Catalog: opts.from,
 		Kind:    opts.kind,
 		Version: opts.version,
 	})
 
-	data, err := resource.Manifest()
+	data, err := resource.ResourceYaml()
 	if err != nil {
 		return err
 	}
@@ -83,9 +83,9 @@ func (opts *taskOptions) run() error {
 	}
 
 	out := opts.cli.Stream().Out
-	return printer.New(out).Raw(data, nil)
+	return printer.New(out).RawYaml(data, nil)
 }
 
-func taskToClusterTask(data []byte) []byte {
-	return bytes.Replace(data, []byte("kind: Task"), []byte("kind: ClusterTask"), 1)
+func taskToClusterTask(data string) string {
+	return strings.ReplaceAll(data, "kind: Task", "kind: ClusterTask")
 }

--- a/api/pkg/cli/hub/hub.go
+++ b/api/pkg/cli/hub/hub.go
@@ -37,6 +37,7 @@ type Client interface {
 	GetCatalogsList() ([]string, error)
 	Search(opt SearchOption) SearchResult
 	GetResource(opt ResourceOption) ResourceResult
+	GetResourceYaml(opt ResourceOption) ResourceResult
 	GetResourcesList(opt SearchOption) ([]string, error)
 	GetResourceVersions(opt ResourceOption) ResourceVersionResult
 	GetResourceVersionslist(opt ResourceOption) ([]string, error)

--- a/api/pkg/cli/printer/print.go
+++ b/api/pkg/cli/printer/print.go
@@ -65,6 +65,16 @@ func (p *Printer) Raw(data []byte, err error) error {
 	return nil
 }
 
+// Raw prints the raw byte array to printer's output stream
+func (p *Printer) RawYaml(data string, err error) error {
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintln(p.out, data)
+	return nil
+}
+
 // String prints the string to printer's output stream
 func (p *Printer) String(str string) error {
 	fmt.Fprintln(p.out, string(str))

--- a/api/test/e2e/get/get_test.go
+++ b/api/test/e2e/get/get_test.go
@@ -16,45 +16,33 @@
 package get
 
 import (
+	"log"
+	"net/http"
 	"testing"
 
-	"github.com/AlecAivazis/survey/v2/terminal"
-	"github.com/Netflix/go-expect"
 	"github.com/stretchr/testify/assert"
 	"github.com/tektoncd/hub/api/test/cli"
 	"gotest.tools/v3/icmd"
 )
 
-const expected = `---
+var task2 = `---
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
-  name: tkn
-  labels:
-    app.kubernetes.io/version: "0.1"
+  name: foo
   annotations:
-    tekton.dev/pipelines.minVersion: "0.12.1"
-    tekton.dev/categories: CLI
+    tekton.dev/pipelines.minVersion: '0.12.1'
     tekton.dev/tags: cli
-    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le"
+    tekton.dev/displayName: 'foo-bar'
 spec:
   description: >-
-    This task performs operations on Tekton resources using tkn
-
-  params:
-  - name: tkn-image
-    description: tkn CLI container image to run this task
-    default: gcr.io/tekton-releases/dogfooding/tkn@sha256:f79c0a56d561b1ae98afca545d0feaf2759f5c486ef891a79f23dc2451167dad #tag: latest
-  - name: ARGS
-    type: array
-    description: tkn CLI arguments to run
-  steps:
-    - name: tkn
-      image: "$(params.tkn-image)"
-      command: ["/usr/local/bin/tkn"]
-      args: ["$(params.ARGS)"]
-
+    v0.1 Task to run foo
 `
+var yamlJson = []byte(`{
+	"data": {
+"yaml": "---\napiVersion: tekton.dev/v1beta1\nkind: Task\nmetadata:\n  name: foo\n  annotations:\n    tekton.dev/pipelines.minVersion: '0.12.1'\n    tekton.dev/tags: cli\n    tekton.dev/displayName: 'foo-bar'\nspec:\n  description: >-\n    v0.1 Task to run foo"
+}
+}`)
 
 func TestGetIneractiveE2E(t *testing.T) {
 	tknhub, err := cli.NewTknHubRunner()
@@ -70,35 +58,18 @@ func TestGetIneractiveE2E(t *testing.T) {
 		})
 
 	})
-	t.Logf("Running Get Command for task")
-
-	t.Run("Interactive mode for get command", func(t *testing.T) {
-		tknhub.RunInteractiveTests(t, &cli.Prompt{
-			CmdArgs: []string{"get", "task"},
-			Procedure: func(c *expect.Console) error {
-				if _, err := c.ExpectString("Select task:"); err != nil {
-					return err
-				}
-				if _, err := c.SendLine("az"); err != nil {
-					return err
-				}
-				if _, err := c.ExpectString("Select version:"); err != nil {
-					return err
-				}
-				if _, err := c.SendLine(string(terminal.KeyEnter)); err != nil {
-					return err
-				}
-				if _, err := c.ExpectEOF(); err != nil {
-					return err
-				}
-
-				c.Close()
-				return nil
-			}})
-	})
 
 	t.Run("Result for get command when resource name and version is passed", func(t *testing.T) {
-		res := tknhub.MustSucceed(t, "get", "task", "tkn", "--version=0.1")
-		assert.Equal(t, expected, res.Stdout())
+
+		go func() {
+			http.HandleFunc("/v1/resource/tekton/task/foo/0.1/yaml", func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(yamlJson))
+			})
+			log.Fatal(http.ListenAndServe(":8080", nil))
+		}()
+
+		res := tknhub.MustSucceed(t, "get", "task", "foo", "--version=0.1", "--from=tekton", "--api-server=http://localhost:8080")
+		assert.Equal(t, task2, res.Stdout())
 	})
 }


### PR DESCRIPTION
- Initially we were fetching the resource yamls from github,
now since we have `/readme` and `/yaml` endpoints we get
the data from api itself, so this patch calls the `/yaml`
api to fetch the resource yaml

- This patch also updates the e2e test, where it creates a
mock api server and mocks the data and assert the output
for `get` command

Signed-off-by: Puneet Punamiya <ppunamiy@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Run API Unit Tests, Lint Checks, API Design, Golden Files with `make api-check`
- [ ] Run UI Unit Tests, Lint Checks with `make ui-check`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._
