### PR TITLE
Trims Api and UI config urls

### DIFF
--- a/api/pkg/auth/base.go
+++ b/api/pkg/auth/base.go
@@ -17,6 +17,7 @@ package auth
 import (
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/gorilla/mux"
 	"github.com/gorilla/sessions"
@@ -50,7 +51,8 @@ func AuthProvider(r *mux.Router, api app.Config) {
 	gothic.Store = store
 
 	var AUTH_BASE_URL = os.Getenv("AUTH_BASE_URL")
-	var AUTH_URL = AUTH_BASE_URL + "/auth/%s/callback"
+
+	var AUTH_URL = strings.TrimSuffix(AUTH_BASE_URL, "/") + "/auth/%s/callback"
 
 	githubAuth := provider.GithubProvider(AUTH_URL)
 	gitlabAuth := provider.GitlabProvider(AUTH_URL)

--- a/ui/src/common/trimUrl.test.ts
+++ b/ui/src/common/trimUrl.test.ts
@@ -1,0 +1,11 @@
+import { TrimUrl } from './trimUrl';
+
+describe('Test TitleCase function', () => {
+  it('Test titleCase function', () => {
+    const nullUrl = TrimUrl('');
+    const url = TrimUrl('https://api.hub.tekton.dev/');
+
+    expect(nullUrl).toEqual('');
+    expect(url).toEqual('https://api.hub.tekton.dev');
+  });
+});

--- a/ui/src/common/trimUrl.ts
+++ b/ui/src/common/trimUrl.ts
@@ -1,0 +1,12 @@
+/**
+ * This trims the `/` character from url if it has as a last character
+ */
+const trimChar = `/`;
+
+export const TrimUrl = (url: string) => {
+  if (url === '') {
+    return url;
+  } else {
+    return url.charAt(url.length - 1) !== trimChar ? url : url.slice(0, -1);
+  }
+};

--- a/ui/src/config/constants.tsx
+++ b/ui/src/config/constants.tsx
@@ -1,3 +1,5 @@
+import { TrimUrl } from '../common/trimUrl';
+
 window.config = window.config || {
   API_URL: 'no API_URL  set',
   API_VERSION: 'no API_VERSION set',
@@ -5,7 +7,7 @@ window.config = window.config || {
   REDIRECT_URI: 'no REDIRECT_URI set'
 };
 
-export const API_URL = window.config.API_URL;
+export const API_URL = TrimUrl(window.config.API_URL);
 export const API_VERSION = window.config.API_VERSION;
-export const AUTH_BASE_URL = window.config.AUTH_BASE_URL;
-export const REDIRECT_URI = window.config.REDIRECT_URI;
+export const AUTH_BASE_URL = TrimUrl(window.config.AUTH_BASE_URL);
+export const REDIRECT_URI = TrimUrl(window.config.REDIRECT_URI);


### PR DESCRIPTION
This patch trims `/` character from config urls if it contains
as a last character,earlier if ui config urls contained `/` then
it was showing cors error on ui

Signed-off-by: Shiv Verma <shverma@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Run API Unit Tests, Lint Checks, API Design, Golden Files with `make api-check`
- [x] Run UI Unit Tests, Lint Checks with `make ui-check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._
