### PR TITLE
Update hub cli commands to use the latest API

### DIFF
--- a/api/pkg/cli/cmd/downgrade/downgrade.go
+++ b/api/pkg/cli/cmd/downgrade/downgrade.go
@@ -35,15 +35,16 @@ const (
 )
 
 type options struct {
-	cli            app.CLI
-	version        string
-	kind           string
-	args           []string
-	kc             kube.Config
-	cs             kube.ClientSet
-	hubRes         hub.ResourceVersionResult
-	hubResVersions *hub.ResVersions
-	resource       *unstructured.Unstructured
+	cli             app.CLI
+	version         string
+	kind            string
+	args            []string
+	kc              kube.Config
+	cs              kube.ClientSet
+	hubRes          hub.ResourceResult
+	hubResVerResult hub.ResourceVersionResult
+	hubResVersions  *hub.ResVersions
+	resource        *unstructured.Unstructured
 }
 
 var cmdExamples string = `
@@ -133,14 +134,14 @@ func (opts *options) run() error {
 	existingVersion := opts.resVersion()
 
 	hubClient := opts.cli.Hub()
-	opts.hubRes = hubClient.GetResourceVersions(hub.ResourceOption{
+	opts.hubResVerResult = hubClient.GetResourceVersions(hub.ResourceOption{
 		Name:    opts.name(),
 		Catalog: catalog,
 		Kind:    opts.kind,
 		Version: existingVersion,
 	})
 
-	opts.hubResVersions, err = opts.hubRes.ResourceVersions()
+	opts.hubResVersions, err = opts.hubResVerResult.ResourceVersions()
 	if err != nil {
 		return err
 	}
@@ -150,7 +151,14 @@ func (opts *options) run() error {
 		return err
 	}
 
-	manifest, err := opts.hubRes.VersionManifest(opts.version)
+	opts.hubRes = hubClient.GetResourceYaml(hub.ResourceOption{
+		Name:    opts.name(),
+		Catalog: catalog,
+		Kind:    opts.kind,
+		Version: opts.version,
+	})
+
+	manifest, err := opts.hubRes.ResourceYaml()
 	if err != nil {
 		return err
 	}
@@ -158,7 +166,7 @@ func (opts *options) run() error {
 	out := opts.cli.Stream().Out
 
 	var errors []error
-	opts.resource, errors = resInstaller.Downgrade(manifest, catalog, opts.cs.Namespace())
+	opts.resource, errors = resInstaller.Downgrade([]byte(manifest), catalog, opts.cs.Namespace())
 	if len(errors) != 0 {
 
 		resourcePipelineMinVersion := opts.resource.GetAnnotations()[installer.ResourceMinVersion]

--- a/api/pkg/cli/cmd/get/get.go
+++ b/api/pkg/cli/cmd/get/get.go
@@ -106,15 +106,20 @@ func (opts *options) run() error {
 		return err
 	}
 
-	resource := opts.hubClient.GetResource(hub.ResourceOption{
+	resource := opts.hubClient.GetResourceYaml(hub.ResourceOption{
 		Name:    name,
 		Catalog: opts.from,
 		Kind:    opts.kind,
 		Version: opts.version,
 	})
 
+	data, err := resource.ResourceYaml()
+	if err != nil {
+		return err
+	}
+
 	out := opts.cli.Stream().Out
-	return printer.New(out).Raw(resource.Manifest())
+	return printer.New(out).Raw([]byte(data), nil)
 }
 
 func (opts *options) validate() error {

--- a/api/pkg/cli/cmd/get/task.go
+++ b/api/pkg/cli/cmd/get/task.go
@@ -15,7 +15,7 @@
 package get
 
 import (
-	"bytes"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/hub/api/pkg/cli/hub"
@@ -66,14 +66,14 @@ func (opts *taskOptions) run() error {
 		return err
 	}
 
-	resource := opts.hubClient.GetResource(hub.ResourceOption{
+	resource := opts.hubClient.GetResourceYaml(hub.ResourceOption{
 		Name:    name,
 		Catalog: opts.from,
 		Kind:    opts.kind,
 		Version: opts.version,
 	})
 
-	data, err := resource.Manifest()
+	data, err := resource.ResourceYaml()
 	if err != nil {
 		return err
 	}
@@ -83,9 +83,9 @@ func (opts *taskOptions) run() error {
 	}
 
 	out := opts.cli.Stream().Out
-	return printer.New(out).Raw(data, nil)
+	return printer.New(out).Raw([]byte(data), nil)
 }
 
-func taskToClusterTask(data []byte) []byte {
-	return bytes.Replace(data, []byte("kind: Task"), []byte("kind: ClusterTask"), 1)
+func taskToClusterTask(data string) string {
+	return strings.ReplaceAll(data, "kind: Task", "kind: ClusterTask")
 }

--- a/api/pkg/cli/cmd/install/install.go
+++ b/api/pkg/cli/cmd/install/install.go
@@ -114,14 +114,28 @@ func (opts *options) run() error {
 	}
 
 	hubClient := opts.cli.Hub()
-	opts.hubRes = hubClient.GetResource(hub.ResourceOption{
+
+	if opts.version == "" {
+		version, err := hubClient.GetResourceVersionslist(hub.ResourceOption{
+			Name:    opts.name(),
+			Catalog: opts.from,
+			Kind:    opts.kind,
+		})
+		if err != nil {
+			return err
+		}
+		// Get the latest version of the resource
+		opts.version = version[0]
+	}
+
+	opts.hubRes = hubClient.GetResourceYaml(hub.ResourceOption{
 		Name:    opts.name(),
 		Catalog: opts.from,
 		Kind:    opts.kind,
 		Version: opts.version,
 	})
 
-	manifest, err := opts.hubRes.Manifest()
+	manifest, err := opts.hubRes.ResourceYaml()
 	if err != nil {
 		return opts.isResourceNotFoundError(err)
 	}
@@ -139,7 +153,7 @@ func (opts *options) run() error {
 	resourceInstaller := installer.New(opts.cs)
 
 	var errors []error
-	opts.resource, errors = resourceInstaller.Install(manifest, opts.from, opts.cs.Namespace())
+	opts.resource, errors = resourceInstaller.Install([]byte(manifest), opts.from, opts.cs.Namespace())
 
 	if len(errors) != 0 {
 		resourcePipelineMinVersion, err := opts.hubRes.MinPipelinesVersion()

--- a/api/pkg/cli/cmd/reinstall/reinstall.go
+++ b/api/pkg/cli/cmd/reinstall/reinstall.go
@@ -54,7 +54,7 @@ Reinstall a %S of name 'foo':
 or
 
 Reinstall a %S of name 'foo' of version '0.3' from Catalog 'Tekton':
-	
+
 	tkn hub reinstall %s foo --version 0.3 --from tekton
 `
 
@@ -131,14 +131,15 @@ func (opts *options) run() error {
 	}
 
 	hubClient := opts.cli.Hub()
-	opts.hubRes = hubClient.GetResource(hub.ResourceOption{
+
+	opts.hubRes = hubClient.GetResourceYaml(hub.ResourceOption{
 		Name:    opts.name(),
 		Catalog: opts.resCatalog(),
 		Kind:    opts.kind,
 		Version: opts.resVersion(),
 	})
 
-	manifest, err := opts.hubRes.Manifest()
+	manifest, err := opts.hubRes.ResourceYaml()
 	if err != nil {
 		return opts.isResourceNotFoundError(err)
 	}
@@ -146,7 +147,7 @@ func (opts *options) run() error {
 	out := opts.cli.Stream().Out
 
 	var errors []error
-	opts.resource, errors = resInstaller.Update(manifest, opts.from, opts.cs.Namespace())
+	opts.resource, errors = resInstaller.Update([]byte(manifest), opts.from, opts.cs.Namespace())
 	if len(errors) != 0 {
 		resourcePipelineMinVersion, vErr := opts.hubRes.MinPipelinesVersion()
 		if vErr != nil {

--- a/api/pkg/cli/cmd/reinstall/reinstall_test.go
+++ b/api/pkg/cli/cmd/reinstall/reinstall_test.go
@@ -16,6 +16,7 @@ package reinstall
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -54,6 +55,26 @@ var resVersion = &res.ResourceVersionData{
 			},
 		},
 	},
+}
+
+var task1 = `---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: foo
+  labels:
+    app.kubernetes.io/version: '0.3'
+  annotations:
+    tekton.dev/pipelines.minVersion: '0.13.1'
+    tekton.dev/tags: cli
+    tekton.dev/displayName: 'foo-bar'
+spec:
+  description: >-
+    v0.3 Task to run foo
+`
+
+var taskWithNewVersionYaml = &res.ResourceContent{
+	Yaml: &task1,
 }
 
 func TestReinstall_ResourceNotExist(t *testing.T) {
@@ -139,17 +160,22 @@ func TestReinstall_DifferentVersionPassedByFlag(t *testing.T) {
 
 	defer gock.Off()
 
+	rVer := &res.ResourceVersionYaml{Data: taskWithNewVersionYaml}
+	resWithVersion := res.NewViewedResourceVersionYaml(rVer, "default")
+
+	resInfo := fmt.Sprintf("%s/%s/%s/%s", "tekton", "task", "foo", "0.3")
+
+	gock.New(test.API).
+		Get("/resource/" + resInfo + "/yaml").
+		Reply(200).
+		JSON(&resWithVersion.Projected)
+
 	resVersion := &res.ResourceVersion{Data: resVersion}
-	res := res.NewViewedResourceVersion(resVersion, "default")
+	resource := res.NewViewedResourceVersion(resVersion, "default")
 	gock.New(test.API).
 		Get("/resource/tekton/task/foo/0.3").
 		Reply(200).
-		JSON(&res.Projected)
-
-	gock.New("http://raw.github.url").
-		Get("/foo/0.3/foo.yaml").
-		Reply(200).
-		File("./testdata/foo-v0.3.yaml")
+		JSON(&resource.Projected)
 
 	buf := new(bytes.Buffer)
 	cli.SetStream(buf, buf)
@@ -188,17 +214,22 @@ func TestReinstall_DifferentCatalogPassedByFlag(t *testing.T) {
 
 	defer gock.Off()
 
+	rVer := &res.ResourceVersionYaml{Data: taskWithNewVersionYaml}
+	resWithVersion := res.NewViewedResourceVersionYaml(rVer, "default")
+
+	resInfo := fmt.Sprintf("%s/%s/%s/%s", "tekton", "task", "foo", "0.3")
+
+	gock.New(test.API).
+		Get("/resource/" + resInfo + "/yaml").
+		Reply(200).
+		JSON(&resWithVersion.Projected)
+
 	resVersion := &res.ResourceVersion{Data: resVersion}
-	res := res.NewViewedResourceVersion(resVersion, "default")
+	resource := res.NewViewedResourceVersion(resVersion, "default")
 	gock.New(test.API).
 		Get("/resource/tekton/task/foo/0.3").
 		Reply(200).
-		JSON(&res.Projected)
-
-	gock.New("http://raw.github.url").
-		Get("/foo/0.3/foo.yaml").
-		Reply(200).
-		File("./testdata/foo-v0.3.yaml")
+		JSON(&resource.Projected)
 
 	buf := new(bytes.Buffer)
 	cli.SetStream(buf, buf)
@@ -240,17 +271,22 @@ func TestReinstall(t *testing.T) {
 
 	defer gock.Off()
 
+	rVer := &res.ResourceVersionYaml{Data: taskWithNewVersionYaml}
+	resWithVersion := res.NewViewedResourceVersionYaml(rVer, "default")
+
+	resInfo := fmt.Sprintf("%s/%s/%s/%s", "tekton", "task", "foo", "0.3")
+
+	gock.New(test.API).
+		Get("/resource/" + resInfo + "/yaml").
+		Reply(200).
+		JSON(&resWithVersion.Projected)
+
 	resVersion := &res.ResourceVersion{Data: resVersion}
-	res := res.NewViewedResourceVersion(resVersion, "default")
+	resource := res.NewViewedResourceVersion(resVersion, "default")
 	gock.New(test.API).
 		Get("/resource/tekton/task/foo/0.3").
 		Reply(200).
-		JSON(&res.Projected)
-
-	gock.New("http://raw.github.url").
-		Get("/foo/0.3/foo.yaml").
-		Reply(200).
-		File("./testdata/foo-v0.3.yaml")
+		JSON(&resource.Projected)
 
 	buf := new(bytes.Buffer)
 	cli.SetStream(buf, buf)
@@ -289,18 +325,22 @@ func TestReinstall_RespectPipelinesVersionSuccess(t *testing.T) {
 
 	defer gock.Off()
 
+	rVer := &res.ResourceVersionYaml{Data: taskWithNewVersionYaml}
+	resWithVersion := res.NewViewedResourceVersionYaml(rVer, "default")
+
+	resInfo := fmt.Sprintf("%s/%s/%s/%s", "tekton", "task", "foo", "0.3")
+
+	gock.New(test.API).
+		Get("/resource/" + resInfo + "/yaml").
+		Reply(200).
+		JSON(&resWithVersion.Projected)
+
 	resVersion := &res.ResourceVersion{Data: resVersion}
-	res := res.NewViewedResourceVersion(resVersion, "default")
+	resource := res.NewViewedResourceVersion(resVersion, "default")
 	gock.New(test.API).
 		Get("/resource/tekton/task/foo/0.3").
 		Reply(200).
-		JSON(&res.Projected)
-
-	gock.New("http://raw.github.url").
-		Get("/foo/0.3/foo.yaml").
-		Reply(200).
-		File("./testdata/foo-v0.3.yaml")
-
+		JSON(&resource.Projected)
 	buf := new(bytes.Buffer)
 	cli.SetStream(buf, buf)
 
@@ -343,17 +383,22 @@ func TestReinstall_RespectPipelinesVersionFailure(t *testing.T) {
 
 	defer gock.Off()
 
+	rVer := &res.ResourceVersionYaml{Data: taskWithNewVersionYaml}
+	resWithVersion := res.NewViewedResourceVersionYaml(rVer, "default")
+
+	resInfo := fmt.Sprintf("%s/%s/%s/%s", "tekton", "task", "foo", "0.3")
+
+	gock.New(test.API).
+		Get("/resource/" + resInfo + "/yaml").
+		Reply(200).
+		JSON(&resWithVersion.Projected)
+
 	resVersion := &res.ResourceVersion{Data: resVersion}
-	res := res.NewViewedResourceVersion(resVersion, "default")
+	resource := res.NewViewedResourceVersion(resVersion, "default")
 	gock.New(test.API).
 		Get("/resource/tekton/task/foo/0.3").
 		Reply(200).
-		JSON(&res.Projected)
-
-	gock.New("http://raw.github.url").
-		Get("/foo/0.3/foo.yaml").
-		Reply(200).
-		File("./testdata/foo-v0.3.yaml")
+		JSON(&resource.Projected)
 
 	buf := new(bytes.Buffer)
 	cli.SetStream(buf, buf)

--- a/api/pkg/cli/cmd/upgrade/upgrade_test.go
+++ b/api/pkg/cli/cmd/upgrade/upgrade_test.go
@@ -16,6 +16,7 @@ package upgrade
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -54,6 +55,26 @@ var resVersion = &res.ResourceVersionData{
 			},
 		},
 	},
+}
+
+var task1 = `---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: foo
+  labels:
+    app.kubernetes.io/version: '0.3'
+  annotations:
+    tekton.dev/pipelines.minVersion: '0.13.1'
+    tekton.dev/tags: cli
+    tekton.dev/displayName: 'foo-bar'
+spec:
+  description: >-
+    v0.3 Task to run foo
+`
+
+var taskWithNewVersionYaml = &res.ResourceContent{
+	Yaml: &task1,
 }
 
 func TestUpgrade_ResourceNotExist(t *testing.T) {
@@ -139,17 +160,22 @@ func TestUpgrade_ToSpecificVersion(t *testing.T) {
 
 	defer gock.Off()
 
+	rVer := &res.ResourceVersionYaml{Data: taskWithNewVersionYaml}
+	resWithVersion := res.NewViewedResourceVersionYaml(rVer, "default")
+
+	resInfo := fmt.Sprintf("%s/%s/%s/%s", "tekton", "task", "foo", "0.3")
+
+	gock.New(test.API).
+		Get("/resource/" + resInfo + "/yaml").
+		Reply(200).
+		JSON(&resWithVersion.Projected)
+
 	resVersion := &res.ResourceVersion{Data: resVersion}
-	res := res.NewViewedResourceVersion(resVersion, "default")
+	resource := res.NewViewedResourceVersion(resVersion, "default")
 	gock.New(test.API).
 		Get("/resource/tekton/task/foo/0.3").
 		Reply(200).
-		JSON(&res.Projected)
-
-	gock.New("http://raw.github.url").
-		Get("/foo/0.3/foo.yaml").
-		Reply(200).
-		File("./testdata/foo-v0.3.yaml")
+		JSON(&resource.Projected)
 
 	buf := new(bytes.Buffer)
 	cli.SetStream(buf, buf)
@@ -189,17 +215,22 @@ func TestUpgrade_SameVersionError(t *testing.T) {
 
 	defer gock.Off()
 
+	rVer := &res.ResourceVersionYaml{Data: taskWithNewVersionYaml}
+	resWithVersion := res.NewViewedResourceVersionYaml(rVer, "default")
+
+	resInfo := fmt.Sprintf("%s/%s/%s/%s", "tekton", "task", "foo", "0.3")
+
+	gock.New(test.API).
+		Get("/resource/" + resInfo + "/yaml").
+		Reply(200).
+		JSON(&resWithVersion.Projected)
+
 	resVersion := &res.ResourceVersion{Data: resVersion}
-	res := res.NewViewedResourceVersion(resVersion, "default")
+	resource := res.NewViewedResourceVersion(resVersion, "default")
 	gock.New(test.API).
 		Get("/resource/tekton/task/foo/0.3").
 		Reply(200).
-		JSON(&res.Projected)
-
-	gock.New("http://raw.github.url").
-		Get("/foo/0.3/foo.yaml").
-		Reply(200).
-		File("./testdata/foo-v0.3.yaml")
+		JSON(&resource.Projected)
 
 	existingTask := &v1beta1.Task{
 		ObjectMeta: metav1.ObjectMeta{
@@ -236,17 +267,22 @@ func TestUpgrade_LowerVersionError(t *testing.T) {
 
 	defer gock.Off()
 
+	rVer := &res.ResourceVersionYaml{Data: taskWithNewVersionYaml}
+	resWithVersion := res.NewViewedResourceVersionYaml(rVer, "default")
+
+	resInfo := fmt.Sprintf("%s/%s/%s/%s", "tekton", "task", "foo", "0.3")
+
+	gock.New(test.API).
+		Get("/resource/" + resInfo + "/yaml").
+		Reply(200).
+		JSON(&resWithVersion.Projected)
+
 	resVersion := &res.ResourceVersion{Data: resVersion}
-	res := res.NewViewedResourceVersion(resVersion, "default")
+	resource := res.NewViewedResourceVersion(resVersion, "default")
 	gock.New(test.API).
 		Get("/resource/tekton/task/foo/0.3").
 		Reply(200).
-		JSON(&res.Projected)
-
-	gock.New("http://raw.github.url").
-		Get("/foo/0.3/foo.yaml").
-		Reply(200).
-		File("./testdata/foo-v0.3.yaml")
+		JSON(&resource.Projected)
 
 	existingTask := &v1beta1.Task{
 		ObjectMeta: metav1.ObjectMeta{
@@ -283,17 +319,22 @@ func TestUpgrade_ToSpecificVersion_RespectingPipelineSuccess(t *testing.T) {
 
 	defer gock.Off()
 
+	rVer := &res.ResourceVersionYaml{Data: taskWithNewVersionYaml}
+	resWithVersion := res.NewViewedResourceVersionYaml(rVer, "default")
+
+	resInfo := fmt.Sprintf("%s/%s/%s/%s", "tekton", "task", "foo", "0.3")
+
+	gock.New(test.API).
+		Get("/resource/" + resInfo + "/yaml").
+		Reply(200).
+		JSON(&resWithVersion.Projected)
+
 	resVersion := &res.ResourceVersion{Data: resVersion}
-	res := res.NewViewedResourceVersion(resVersion, "default")
+	resource := res.NewViewedResourceVersion(resVersion, "default")
 	gock.New(test.API).
 		Get("/resource/tekton/task/foo/0.3").
 		Reply(200).
-		JSON(&res.Projected)
-
-	gock.New("http://raw.github.url").
-		Get("/foo/0.3/foo.yaml").
-		Reply(200).
-		File("./testdata/foo-v0.3.yaml")
+		JSON(&resource.Projected)
 
 	buf := new(bytes.Buffer)
 	cli.SetStream(buf, buf)
@@ -338,17 +379,22 @@ func TestUpgrade_ToSpecificVersion_RespectingPipelineFailure(t *testing.T) {
 
 	defer gock.Off()
 
+	rVer := &res.ResourceVersionYaml{Data: taskWithNewVersionYaml}
+	resWithVersion := res.NewViewedResourceVersionYaml(rVer, "default")
+
+	resInfo := fmt.Sprintf("%s/%s/%s/%s", "tekton", "task", "foo", "0.3")
+
+	gock.New(test.API).
+		Get("/resource/" + resInfo + "/yaml").
+		Reply(200).
+		JSON(&resWithVersion.Projected)
+
 	resVersion := &res.ResourceVersion{Data: resVersion}
-	res := res.NewViewedResourceVersion(resVersion, "default")
+	resource := res.NewViewedResourceVersion(resVersion, "default")
 	gock.New(test.API).
 		Get("/resource/tekton/task/foo/0.3").
 		Reply(200).
-		JSON(&res.Projected)
-
-	gock.New("http://raw.github.url").
-		Get("/foo/0.3/foo.yaml").
-		Reply(200).
-		File("./testdata/foo-v0.3.yaml")
+		JSON(&resource.Projected)
 
 	buf := new(bytes.Buffer)
 	cli.SetStream(buf, buf)

--- a/api/pkg/cli/hub/get_resource_version.go
+++ b/api/pkg/cli/hub/get_resource_version.go
@@ -17,7 +17,6 @@ package hub
 import (
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"strconv"
 
 	rclient "github.com/tektoncd/hub/api/v1/gen/http/resource/client"
@@ -91,34 +90,4 @@ func (rvr *ResourceVersionResult) ResourceVersions() (*ResVersions, error) {
 	}
 
 	return rvr.versions, nil
-}
-
-// VersionManifest gets the resource from catalog for the resource's version passed
-func (rvr *ResourceVersionResult) VersionManifest(version string) ([]byte, error) {
-
-	if err := rvr.unmarshalData(); err != nil {
-		return nil, err
-	}
-
-	var rawURL string
-	for _, v := range rvr.versions.Versions {
-		if version == *v.Version {
-			rawURL = *v.RawURL
-			break
-		}
-	}
-	if rawURL == "" {
-		return nil, fmt.Errorf("resource version (v%s) not found", version)
-	}
-
-	data, status, err := httpGet(rawURL)
-	if err != nil {
-		return nil, err
-	}
-
-	if status != http.StatusOK {
-		return nil, fmt.Errorf("failed to fetch resource from catalog")
-	}
-
-	return data, nil
 }

--- a/api/pkg/cli/hub/hub.go
+++ b/api/pkg/cli/hub/hub.go
@@ -37,6 +37,7 @@ type Client interface {
 	GetCatalogsList() ([]string, error)
 	Search(opt SearchOption) SearchResult
 	GetResource(opt ResourceOption) ResourceResult
+	GetResourceYaml(opt ResourceOption) ResourceResult
 	GetResourcesList(opt SearchOption) ([]string, error)
 	GetResourceVersions(opt ResourceOption) ResourceVersionResult
 	GetResourceVersionslist(opt ResourceOption) ([]string, error)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

- Initially we were fetching the resource yamls from github,
now since we have `/readme` and `/yaml` endpoints we get
the data from api itself, so this patch calls the `/yaml`
api to fetch the resource yaml

- With this patch we are updating the following commands
    - get
    - install
    - reinstall
    - upgrade
    - downgrade

Signed-off-by: Puneet Punamiya <ppunamiy@redhat.com>

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Run API Unit Tests, Lint Checks, API Design, Golden Files with `make api-check`
- [ ] Run UI Unit Tests, Lint Checks with `make ui-check`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._
