### PR TITLE
Bump golang to 1.16 in Dockerfile

### DIFF
--- a/images/api.Dockerfile
+++ b/images/api.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15-alpine3.14 AS builder
+FROM golang:1.16-alpine3.14 AS builder
 
 WORKDIR /go/src/github.com/tektoncd/hub
 COPY . .

--- a/images/db.Dockerfile
+++ b/images/db.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15-alpine3.14 AS builder
+FROM golang:1.16-alpine3.14 AS builder
 
 WORKDIR /go/src/github.com/tektoncd/hub
 COPY . .


### PR DESCRIPTION
# Changes

With go version 1.15, docker build is failing with the issue
```
[1/2] STEP 4/4: RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o api-server ./api/cmd/api/...
vendor/k8s.io/client-go/plugin/pkg/client/auth/exec/metrics.go:21:2: cannot find package "." in:
/go/src/github.com/tektoncd/hub/vendor/io/fs
```

Bumping the version 1.16 fixes this. Also go.mod is using the go version
as 1.16.

Signed-off-by: vinamra28 <jvinamra776@gmail.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Run API Unit Tests, Lint Checks, API Design, Golden Files with `make api-check`
- [ ] Run UI Unit Tests, Lint Checks with `make ui-check`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._
