### PR TITLE
Change catalog default clone path and update docs

### DIFF
--- a/api/pkg/git/git.go
+++ b/api/pkg/git/git.go
@@ -146,7 +146,7 @@ func git(log *zap.SugaredLogger, kind string, args ...string) (string, error) {
 	output, err := rawGit(kind, args...)
 
 	if err != nil {
-		log.Errorf("git %s : error %s ;output: %s", strings.Join(args, " "), output)
+		log.Errorf("git %s : error %s ;output: %s", strings.Join(args, " "), err.Error(), output)
 		return "", err
 	}
 	return output, nil

--- a/config/02-api/22-api-deployment.yaml
+++ b/config/02-api/22-api-deployment.yaml
@@ -36,12 +36,14 @@ spec:
         secret:
           secretName: tekton-hub-api-ssh-crds
           optional: true
+      securityContext:
+        fsGroup: 101
       containers:
         - name: tekton-hub-api
           image: quay.io/tekton-hub/api
           volumeMounts:
           - name: catalog-source
-            mountPath: "/tmp"
+            mountPath: "/tmp/catalog"
           - name: ssh-creds
             mountPath: "/home/hub/.ssh"
           ports:

--- a/config/05-catalog-refresh-cj/51-catalog-refresh-cronjob.yaml
+++ b/config/05-catalog-refresh-cj/51-catalog-refresh-cronjob.yaml
@@ -23,6 +23,6 @@ spec:
               args: [
                 "-i", "-X", "POST",
                 "-H", "Authorization:$(HUB_TOKEN)",
-                "api:8000/catalog/tekton/refresh"
+                "tekton-hub-api:8000/catalog/tekton/refresh"
               ]
           restartPolicy: OnFailure

--- a/config/06-swagger/01-kubernetes/01-swagger-ingress.yaml
+++ b/config/06-swagger/01-kubernetes/01-swagger-ingress.yaml
@@ -1,7 +1,7 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: swagger
+  name: tekton-hub-swagger
   annotations:
     acme.cert-manager.io/http01-edit-in-place: 'true'
     cert-manager.io/cluster-issuer: letsencrypt-prod

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -253,6 +253,27 @@ please follow the below steps:
    ```
    Please make sure that secrets are created with the name `tekton-hub-api-ssh-crds`
 
+### Update API deployment (Optional)
+
+By default the catalog is cloned in `$HOME/catalog`. If in case you want to change the clone path, edit the `02-api/22-api-deployment.yaml`
+with the following
+
+```yaml
+spec:
+  ...
+    spec:
+      ...
+      containers:
+        - ...
+          volumeMounts:
+          - name: catalog-source
+            mountPath: "/home/hub/catalog" <---- change here with path/where/catalog/to/be/cloned eg /tmp/catalog
+          ...
+          env:
+          - name: CLONE_BASE_PATH
+            value: <path/where/catalog/to/be/cloned> eg /tmp/catalog
+```
+
 ### Update API Image
 
 Edit the `02-api/22-api-deployment.yaml` and replace the image with the one created previously and executed below command


### PR DESCRIPTION
# Changes

Earlier we used to clone the catalog in `/tmp/catalog` but user may not
have proper rights to clone in this path. Changing this path to
`$HOME/catalog`.

Update the deployment docs and deployment manifests.

Signed-off-by: vinamra28 <jvinamra776@gmail.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [X] Run API Unit Tests, Lint Checks, API Design, Golden Files with `make api-check`
- [X] Run UI Unit Tests, Lint Checks with `make ui-check`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._
