### PR TITLE
Adds `buildvcs=false` flag in API and Db migration Dockerfile

### DIFF
--- a/images/api.Dockerfile
+++ b/images/api.Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.18.0-alpine3.14 AS builder
 WORKDIR /go/src/github.com/tektoncd/hub
 COPY . .
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o api-server ./api/cmd/api/...
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -buildvcs=false -o api-server ./api/cmd/api/...
 
 FROM alpine:3.15.4
 

--- a/images/db.Dockerfile
+++ b/images/db.Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.18.0-alpine3.14 AS builder
 WORKDIR /go/src/github.com/tektoncd/hub
 COPY . .
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o db-migration ./api/cmd/db/...
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -buildvcs=false -o db-migration ./api/cmd/db/...
 
 FROM alpine:3.15.4
 


### PR DESCRIPTION
With go.1.8 api and db-migration dockerfile was unable to build an image and it had error as

`go: missing Git command. See https://golang.org/s/gogetcmd
error obtaining VCS status: exec: "git": executable file not found in $PATH`

Hence this patch adds `-buildvcs-false` while doing `go build` in Dockerfile
to successfully build an image

Signed-off-by: Puneet Punamiya <ppunamiy@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Run API Unit Tests, Lint Checks, API Design, Golden Files with `make api-check`
- [ ] Run UI Unit Tests, Lint Checks with `make ui-check`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._
