### PR TITLE
Allow sorting the resources by Last Updated At

### DIFF
--- a/ui/src/components/LeftPane/index.tsx
+++ b/ui/src/components/LeftPane/index.tsx
@@ -6,6 +6,7 @@ import KindFilter from '../../containers/KindFilter';
 import CategoryFilter from '../../containers/CategoryFilter';
 import PlatformFilter from '../../containers/PlatformFilter';
 import Sort from '../../containers/SortDropDown';
+import { SortByFields } from '../../store/resource';
 import { useMst } from '../../store/root';
 import { apiDownError } from '../../common/errors';
 import './LeftPane.css';
@@ -16,7 +17,7 @@ const LeftPane: React.FC = () => {
   return useObserver(() =>
     resources.err !== apiDownError ? (
       <Grid hasGutter className="hub-leftpane">
-        <GridItem span={8}>
+        <GridItem span={resources.sortBy == SortByFields.RecentlyUpdated ? 10 : 8}>
           <Sort />
         </GridItem>
         <GridItem>

--- a/ui/src/containers/SortDropDown/SortDropDown.css
+++ b/ui/src/containers/SortDropDown/SortDropDown.css
@@ -7,3 +7,8 @@ input {
 button {
   outline: none;
 }
+
+.hub-sort *,
+button > svg {
+  margin-right: -0.35em !important;
+}

--- a/ui/src/containers/SortDropDown/SortDropDown.test.tsx
+++ b/ui/src/containers/SortDropDown/SortDropDown.test.tsx
@@ -26,6 +26,6 @@ describe('Sort DropDown', () => {
 
     const keys = item.props().children;
     assert(keys);
-    expect(keys.length).toBe(2);
+    expect(keys.length).toBe(3);
   });
 });

--- a/ui/src/containers/SortDropDown/index.tsx
+++ b/ui/src/containers/SortDropDown/index.tsx
@@ -39,7 +39,9 @@ const Sort: React.FC = () => {
     else {
       value.toString() === SortByFields.Name
         ? resources.setSortBy(SortByFields.Name)
-        : resources.setSortBy(SortByFields.Rating);
+        : value.toString() === SortByFields.Rating
+        ? resources.setSortBy(SortByFields.Rating)
+        : resources.setSortBy(SortByFields.RecentlyUpdated);
       setIsOpen(false);
     }
   };

--- a/ui/src/store/resource.test.ts
+++ b/ui/src/store/resource.test.ts
@@ -410,6 +410,30 @@ describe('Store functions', () => {
     );
   });
 
+  it('should sort resources based on last updated at', (done) => {
+    const store = ResourceStore.create(
+      {},
+      {
+        api,
+        catalogs: CatalogStore.create({}, { api }),
+        categories: CategoryStore.create({}, { api })
+      }
+    );
+    expect(store.isLoading).toBe(true);
+    when(
+      () => !store.isLoading,
+      () => {
+        const lastUpdated: SortByFields = SortByFields[SortByFields.RecentlyUpdated];
+        store.setSortBy(lastUpdated);
+
+        expect(store.filteredResources[0].rating).toBe(4);
+        expect(store.filteredResources[0].name).toBe(`buildah`);
+
+        done();
+      }
+    );
+  });
+
   it('it should return webURL', (done) => {
     const store = ResourceStore.create(
       {},

--- a/ui/src/store/resource.ts
+++ b/ui/src/store/resource.ts
@@ -111,7 +111,8 @@ export type IVersion = Instance<typeof Version>;
 export enum SortByFields {
   Unknown = '',
   Name = 'Name',
-  Rating = 'Rating'
+  Rating = 'Rating',
+  RecentlyUpdated = 'RecentlyUpdated'
 }
 
 export const ResourceStore = types
@@ -471,6 +472,14 @@ export const ResourceStore = types
         case SortByFields.Name:
           return filteredItems.sort((first: IResource, second: IResource) =>
             first.name > second.name ? 1 : first.name < second.name ? -1 : 0
+          );
+
+        case SortByFields.RecentlyUpdated:
+          return filteredItems.sort((first: IResource, second: IResource) =>
+            first.latestVersion.updatedAt.toDate().getTime() <
+            second.latestVersion.updatedAt.toDate().getTime()
+              ? 1
+              : -1
           );
 
         default:


### PR DESCRIPTION
# Changes

Currently hub allows sorting of resources by name or rating. A user
might want to reorder the resources on the basis of their last updated
date. Adding one more parameter of LastUpdated in Dropdown of sorting.


<img width="1512" alt="Screenshot 2022-07-28 at 10 17 37 AM" src="https://user-images.githubusercontent.com/26500025/181422828-059109b9-0f21-4d54-832a-f84a3e3cbc94.png">



closes #371 

Signed-off-by: vinamra28 <jvinamra776@gmail.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [X] Run API Unit Tests, Lint Checks, API Design, Golden Files with `make api-check`
- [X] Run UI Unit Tests, Lint Checks with `make ui-check`
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._