### PR TITLE
Split the nginx.conf by separating locations directive

### DIFF
--- a/images/ui.Dockerfile
+++ b/images/ui.Dockerfile
@@ -24,5 +24,6 @@ USER nginx
 EXPOSE 8080
 
 COPY ui/image/nginx.conf /etc/nginx/conf.d/default.conf
+COPY ui/image/location.locations /etc/nginx/conf.d/location.locations
 
 CMD /usr/bin/start.sh

--- a/ui/image/location.locations
+++ b/ui/image/location.locations
@@ -1,0 +1,8 @@
+location / {
+		index  index.html index.htm;
+		try_files $uri /index.html;
+}
+
+error_page   500 502 503 504  /50x.html;
+location = /50x.html {
+}

--- a/ui/image/nginx.conf
+++ b/ui/image/nginx.conf
@@ -1,24 +1,16 @@
 server {
     listen       8080;
     server_name  localhost;
+    root   /usr/share/nginx/html;
 
     #charset koi8-r;
     #access_log  /var/log/nginx/host.access.log  main;
 
-    location / {
-        root   /usr/share/nginx/html;
-        index  index.html index.htm;
-        try_files $uri /index.html;
-    }
+    include /etc/nginx/conf.d/location.locations;
 
     #error_page  404              /404.html;
 
     # redirect server error pages to the static page /50x.html
-    #
-    error_page   500 502 503 504  /50x.html;
-    location = /50x.html {
-        root   /usr/share/nginx/html;
-    }
 
     # proxy the PHP scripts to Apache listening on 127.0.0.1:80
     #


### PR DESCRIPTION
  * This will split the nginx.conf file by separating the locations
    directive into another file and including in nginx.conf
    
*  This is to make it work with images like `registry.access.redhat.com/ubi8/nginx-120`
    where the nginx.conf is present and only locations directive is required
    
* Also updates the UI dockerfile to copy the new file

Signed-off-by: Puneet Punamiya <ppunamiy@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Run API Unit Tests, Lint Checks, API Design, Golden Files with `make api-check`
- [ ] Run UI Unit Tests, Lint Checks with `make ui-check`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._
