### PR TITLE
Fix spinner css and update css classname

### DIFF
--- a/ui/src/components/Description/Description.css
+++ b/ui/src/components/Description/Description.css
@@ -87,7 +87,7 @@ code {
 
 .hub-details-spinner {
   position: fixed;
-  left: 0;
+  left: 48%;
   right: 0;
   top: 2em;
   bottom: 0;

--- a/ui/src/containers/App/__snapshots__/App.test.tsx.snap
+++ b/ui/src/containers/App/__snapshots__/App.test.tsx.snap
@@ -313,8 +313,8 @@ exports[`App should render the component correctly and match the snapshot 1`] = 
                           <div className=\\"pf-l-grid__item pf-m-10-col pf-m-1-row\\" style={[undefined]}>
                             <Route exact={true} path=\\"/\\" component={{...}}>
                               <Memo(wrappedComponent) history={{...}} location={{...}} match={{...}} staticContext={[undefined]}>
-                                <Spinner className=\\"hub-spinner\\">
-                                  <span className=\\"pf-c-spinner pf-m-xl hub-spinner\\" role=\\"progressbar\\" aria-valuetext=\\"Loading...\\" aria-label=\\"Contents\\">
+                                <Spinner className=\\"hub-resources-spinner\\">
+                                  <span className=\\"pf-c-spinner pf-m-xl hub-resources-spinner\\" role=\\"progressbar\\" aria-valuetext=\\"Loading...\\" aria-label=\\"Contents\\">
                                     <span className=\\"pf-c-spinner__clipper\\" />
                                     <span className=\\"pf-c-spinner__lead-ball\\" />
                                     <span className=\\"pf-c-spinner__tail-ball\\" />

--- a/ui/src/containers/Details/__snapshots__/Details.test.tsx.snap
+++ b/ui/src/containers/Details/__snapshots__/Details.test.tsx.snap
@@ -4,8 +4,8 @@ exports[`Details component should render the details component 1`] = `
 "<Provider>
    
   <Memo(wrappedComponent)>
-    <Spinner className=\\"hub-spinner\\">
-      <span className=\\"pf-c-spinner pf-m-xl hub-spinner\\" role=\\"progressbar\\" aria-valuetext=\\"Loading...\\" aria-label=\\"Contents\\">
+    <Spinner className=\\"hub-details-spinner\\">
+      <span className=\\"pf-c-spinner pf-m-xl hub-details-spinner\\" role=\\"progressbar\\" aria-valuetext=\\"Loading...\\" aria-label=\\"Contents\\">
         <span className=\\"pf-c-spinner__clipper\\" />
         <span className=\\"pf-c-spinner__lead-ball\\" />
         <span className=\\"pf-c-spinner__tail-ball\\" />

--- a/ui/src/containers/Details/index.tsx
+++ b/ui/src/containers/Details/index.tsx
@@ -55,7 +55,7 @@ const Details: React.FC = observer(() => {
   };
 
   return resources.isVersionLoading === true ? (
-    <Spinner className="hub-spinner" />
+    <Spinner className="hub-details-spinner" />
   ) : !validateUrl() ? (
     <PageNotFound />
   ) : (

--- a/ui/src/containers/Resources/Resources.css
+++ b/ui/src/containers/Resources/Resources.css
@@ -2,9 +2,9 @@
   padding-top: 2.2em;
 }
 
-.hub-spinner {
+.hub-resources-spinner {
   position: fixed;
-  left: 0;
+  left: 38%;
   right: 0;
   top: 0;
   bottom: 0;

--- a/ui/src/containers/Resources/index.tsx
+++ b/ui/src/containers/Resources/index.tsx
@@ -73,7 +73,7 @@ const Resources: React.FC = observer(() => {
   };
 
   return resources.resources.size === 0 ? (
-    <Spinner className="hub-spinner" />
+    <Spinner className="hub-resources-spinner" />
   ) : (
     <React.Fragment>{checkResources(resources.filteredResources)}</React.Fragment>
   );


### PR DESCRIPTION
This patch fixes css of spinner to move it on the center
of screen earlier it was showing on left of screen

Signed-off-by: Shiv Verma <shverma@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->



<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Run API Unit Tests, Lint Checks, API Design, Golden Files with `make api-check`
- [ ] Run UI Unit Tests, Lint Checks with `make ui-check`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._
