### PR TITLE
Add resources to database during api start

### DIFF
--- a/api/pkg/service/catalog/catalog.go
+++ b/api/pkg/service/catalog/catalog.go
@@ -46,7 +46,7 @@ var errorTypes = []string{
 // New returns the catalog service implementation.
 func New(api app.Config) catalog.Service {
 	svc := validator.NewService(api, "catalog")
-	wq := newSyncer(api, svc.CatalogClonePath())
+	wq := NewSyncer(api, svc.CatalogClonePath())
 
 	// start running after some delay to allow for all services to mount
 	time.AfterFunc(3*time.Second, wq.Run)

--- a/api/pkg/service/catalog/catalog_test.go
+++ b/api/pkg/service/catalog/catalog_test.go
@@ -28,7 +28,7 @@ import (
 // NewServiceTest returns the catalog service implementation for test.
 func NewServiceTest(api app.Config) catalog.Service {
 	svc := validator.NewService(api, "catalog")
-	wq := newSyncer(api, "")
+	wq := NewSyncer(api, "")
 
 	s := &service{
 		svc,

--- a/api/pkg/service/catalog/syncer.go
+++ b/api/pkg/service/catalog/syncer.go
@@ -42,7 +42,7 @@ var (
 	running = &model.SyncJob{Status: model.JobRunning.String()}
 )
 
-func newSyncer(api app.BaseConfig, clonePath string) *syncer {
+func NewSyncer(api app.BaseConfig, clonePath string) *syncer {
 	logger := api.Logger("syncer")
 	return &syncer{
 		db:        app.DBWithLogger(api.Environment(), api.DB(), logger),

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -13,7 +13,7 @@
   - [Update UI ConfigMap](#update-ui-configmap)
   - [Update UI Image](#update-ui-image)
   - [Setup Ingress/Route](#setup-route-or-ingress)
-- [Add resources in DB](#add-resources-in-db)
+- [Update Catalog and Catalog Refresh](#update-catalog-and-catalog-refresh)
 - [Setup Catalog Refresh CronJob](#setup-catalog-refresh-cronjob)
 - [Adding New Users in Config](#adding-new-users-in-config)
 - [Deploying on Disconnected Cluster](#deploying-on-disconnected)
@@ -292,10 +292,6 @@ For `OpenShift`:-
 curl -k -X GET $(oc get -n tekton-hub routes api --template='https://{{ .spec.host }}/v1/categories')
 ```
 
-NOTE: At this moment, there are no resources in the db. Only the categories from hub config are added in the db.
-
-Let's deploy the UI first and then we will add the resources in db.
-
 ## Deploy UI
 
 ### Setup Route or Ingress
@@ -381,17 +377,28 @@ For `OpenShift`:-
 
 Open the URL in a browser.
 
-Note: In UI you won't be able see the resources on homepage as there are not any in the db but you should see Categories on the left side.
+Note: On UI, you should be able to see the resources on homepage and Categories on the left side.
 
 Update your GitHub OAuth created with the UI route in place of `Homepage URL` and `Authorization callback URL`.
 
-## Add resources in DB
+## Update Catalog and Catalog Refresh
 
-1. Login through the Hub UI. Click on `Login` on right corner and then `Sign in with GitHub/Github Enterprise`.
+If you have added and modified catalog in the config file , then you will have to folllow following steps to see resources from catalog on Hub UI
 
+1. Login through the Hub UI. Click on Login on right corner and then Sign in with GitHub/Github Enterprise.
 2. Copy the Hub Token by clicking on the user profile which is at the right corner on the Home Page
+3. Refresh the config file and you need to have `config:refresh` scope.
 
-3. Call the Catalog Refresh API:
+   - To Refresh config file
+
+     ```
+       curl -X POST -H "Authorization: <access-token>" \
+       --header "Content-Type: application/json" \
+       --data '{"force": true} \
+       <api-route>/system/config/refresh
+     ```
+
+4. Call the Catalog Refresh API:
 
    - To refresh a catalog with name
 
@@ -423,7 +430,7 @@ Update your GitHub OAuth created with the UI route in place of `Homepage URL` an
      [{"id":1,"catalogName":"tekton","status":"queued"}]
      ```
 
-4. Refresh your UI, you will be able to see resources.
+5. Refresh your UI, you will be able to see resources.
 
 ## Setup Catalog Refresh CronJob (Optional)
 
@@ -485,7 +492,7 @@ Now, we need to refresh the config. To do that do a POST API call.
 ```
 curl -X POST -H "Authorization: <access-token>" \
     --header "Content-Type: application/json" \
-    --data '{"force": true} \
+    --data '{"force": true}' \
   <api-route>/system/config/refresh
 ```
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -94,13 +94,11 @@ Wait until the migration completes and logs to show
 
 > DB initialisation successful !!
 
-### Adding GitHub OAuth Configuration
+### Adding GitHub OAuth Configuration (Optional)
 
 Create a GitHub OAuth. You can find the steps to create it [here][gh-oauth] with `Authorization callback URL` as `http://localhost:4200` \
 Create a Gitlab OAuth. You can find the steps to create it [here][gl-oauth] with `Authorization callback URL` as `http://localhost:4200/auth/gitlab/callback` \
 Create a BitBucket OAuth. You can find the steps to create it [here][bb-oauth] with `Authorization callback URL` as `http://localhost:4200`
-
-
 
 After creation, add the OAuth Client ID as \
 OAuth Client ID `GH_CLIENT_ID` and Client Secret as `GH_CLIENT_SECRET` for Github \


### PR DESCRIPTION
This patch adds  following 
- Adds an `apiserver` user with catalog refresh scope
and adds resources from catalogs to the database only during
first time api start

- Now user don't need to login on Hub ui inorder to add
 resources to db from catalog, it would add automatically
 during api start so this commit updates docs accordingly



Signed-off-by: Shiv Verma <shverma@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [x] Run API Unit Tests, Lint Checks, API Design, Golden Files with `make api-check`
- [ ] Run UI Unit Tests, Lint Checks with `make ui-check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._
