### PR TITLE
Adds `POSTGRES_HOST` as a secret for db

### DIFF
--- a/config/00-init/01-db-secret.yaml
+++ b/config/00-init/01-db-secret.yaml
@@ -20,6 +20,7 @@ metadata:
     app: tekton-hub-db
 type: Opaque
 stringData:
+  POSTGRES_HOST: tekton-hub-db
   POSTGRES_DB: hub
   POSTGRES_USER: postgres
   POSTGRES_PASSWORD: postgres

--- a/config/01-db/10-db-migration.yaml
+++ b/config/01-db/10-db-migration.yaml
@@ -26,7 +26,10 @@ spec:
           image: quay.io/tekton-hub/db-migration
           env:
             - name: POSTGRES_HOST
-              value: tekton-hub-db
+              valueFrom:
+                secretKeyRef:
+                  name: tekton-hub-db
+                  key: POSTGRES_HOST
             - name: POSTGRES_PORT
               valueFrom:
                 secretKeyRef:

--- a/config/02-api/22-api-deployment.yaml
+++ b/config/02-api/22-api-deployment.yaml
@@ -78,7 +78,10 @@ spec:
             - name: HOME
               value: /home/hub
             - name: POSTGRES_HOST
-              value: tekton-hub-db
+              valueFrom:
+                secretKeyRef:
+                  name: tekton-hub-db
+                  key: POSTGRES_HOST
             - name: POSTGRES_PORT
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
- Initially value for `POSRGRES_HOST` was set to `tekton-hub`,
but if user wants to use his own db then he can just update
the secrets of db and just use the api and ui services

-  Hence this patch adds host as well with other fields required
for connecting a database

Signed-off-by: Puneet Punamiya <ppunamiy@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Run API Unit Tests, Lint Checks, API Design, Golden Files with `make api-check`
- [ ] Run UI Unit Tests, Lint Checks with `make ui-check`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._
