### PR TITLE
Fix CI unit test goa gen comparison bug

### DIFF
--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -122,7 +122,7 @@ goa-gen() {
   }
 
   files=$(git diff api | wc -l)
-	if [[ ${files} == 0 ]];then
+	if [[ ${files} -eq 0 ]];then
     echo "    Git repo is clean."
   else
     echo "---------------------------------------"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Prior to this change, the script uses alphabetic comparator```==``` to check git diff files. The result of ```$(git diff api | wc -l)``` contains white spaces which makes the comparison to ```0``` always fail. This commit fixes the issue by changing the 
alphabetic comparator to arithmetic comparator ```-eq```

/kind bug

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Run API Unit Tests, Lint Checks, API Design, Golden Files with `make api-check`
- [ ] Run UI Unit Tests, Lint Checks with `make ui-check`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._
