### PR TITLE
Updates Install command on description page

### DIFF
--- a/ui/src/config/constants.tsx
+++ b/ui/src/config/constants.tsx
@@ -1,8 +1,8 @@
 import { TrimUrl } from '../common/trimUrl';
 
 window.config = window.config || {
-  API_URL: 'no API_URL  set',
-  API_VERSION: 'no API_VERSION set',
+  API_URL: 'https://fake.api.hub.tekton.dev',
+  API_VERSION: 'v1',
   AUTH_BASE_URL: 'no AUTH_BASE_URL set',
   REDIRECT_URI: 'no REDIRECT_URI set'
 };

--- a/ui/src/store/resource.test.ts
+++ b/ui/src/store/resource.test.ts
@@ -531,7 +531,7 @@ describe('Store functions', () => {
         assert(resource);
 
         expect(resource.installCommand).toBe(
-          'kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/task/aws-cli/0.1/aws-cli.yaml'
+          'kubectl apply -f https://fake.api.hub.tekton.dev/v1/resource/tekton/task/aws-cli/0.1/raw'
         );
         done();
       }

--- a/ui/src/store/resource.ts
+++ b/ui/src/store/resource.ts
@@ -14,6 +14,7 @@ import { Params } from '../common/params';
 import { Tag, TagStore, ITag } from './tag';
 import { TagsKeyword } from '../containers/Search';
 import { apiDownError, serverError, resourceNotFoundError } from '../common/errors';
+import { API_URL, API_VERSION } from '../config/constants';
 
 export const updatedAt = types.custom<string, Moment>({
   name: 'momentDate',
@@ -89,7 +90,9 @@ export const Resource = types
       return index !== -1 ? description.substring(index + 1).trim() : '';
     },
     get installCommand() {
-      return `kubectl apply -f ${self.displayVersion.rawURL}`;
+      return `kubectl apply -f ${API_URL}/${API_VERSION}/resource/${
+        self.catalog.name
+      }/${self.kind.name.toLowerCase()}/${self.name}/${self.displayVersion.version}/raw`;
     },
     get tknInstallCommand() {
       const versionFlag =


### PR DESCRIPTION
Initially raw github url was added in the install command
to install a resource, but since now we have support for
it in the Hub API, this patch updates the command

For example, the command will change from
`kubectl apply -f
https://raw.githubusercontent.com/tektoncd/catalog/main/task/rsync/0.1/rsync.yaml`

to

`kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/rsync/0.1/raw`

Signed-off-by: Puneet Punamiya ppunamiy@redhat.com

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Run API Unit Tests, Lint Checks, API Design, Golden Files with `make api-check`
- [ ] Run UI Unit Tests, Lint Checks with `make ui-check`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._
