### PR TITLE
Add "type" flag to CLI

### DIFF
--- a/api/pkg/cli/app/app.go
+++ b/api/pkg/cli/app/app.go
@@ -15,6 +15,7 @@
 package app
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/tektoncd/hub/api/pkg/cli/hub"
@@ -29,6 +30,7 @@ type CLI interface {
 	Hub() hub.Client
 	Stream() Stream
 	SetStream(out, err io.Writer)
+	SetHub(hubType string) error
 }
 
 type cli struct {
@@ -39,7 +41,7 @@ type cli struct {
 var _ CLI = (*cli)(nil)
 
 func New() *cli {
-	return &cli{hub: hub.NewClient()}
+	return &cli{}
 }
 
 func (c *cli) Stream() Stream {
@@ -52,4 +54,16 @@ func (c *cli) SetStream(out, err io.Writer) {
 
 func (c *cli) Hub() hub.Client {
 	return c.hub
+}
+
+func (c *cli) SetHub(hubType string) error {
+	if hubType == hub.TektonHubType {
+		c.hub = hub.NewTektonHubClient()
+		return nil
+	} else if hubType == hub.ArtifactHubType {
+		c.hub = hub.NewArtifactHubClient()
+		return nil
+	}
+
+	return fmt.Errorf("invalid hub type: %s", hubType)
 }

--- a/api/pkg/cli/cmd/check_upgrade/check_uprade.go
+++ b/api/pkg/cli/cmd/check_upgrade/check_uprade.go
@@ -15,6 +15,7 @@
 package check_upgrade
 
 import (
+	"fmt"
 	"strings"
 	"text/template"
 
@@ -151,6 +152,10 @@ func commandForKind(kind string, opts *options) *cobra.Command {
 }
 
 func (opts *options) run() error {
+	// Todo: support check-upgrade sub command for artifact type
+	if opts.cli.Hub().GetType() == hub.ArtifactHubType {
+		return fmt.Errorf("check-upgrade sub command is not supported for artifact type")
+	}
 
 	var err error
 	if opts.cs == nil {

--- a/api/pkg/cli/cmd/downgrade/downgrade.go
+++ b/api/pkg/cli/cmd/downgrade/downgrade.go
@@ -211,6 +211,11 @@ func (opts *options) findLowerVersion(current string) (string, error) {
 }
 
 func (opts *options) validate() error {
+	// Todo: support downgrade sub command for artifact type
+	if opts.cli.Hub().GetType() == hub.ArtifactHubType {
+		return fmt.Errorf("downgrade sub command is not supported for artifact type")
+	}
+
 	return flag.ValidateVersion(opts.version)
 }
 

--- a/api/pkg/cli/cmd/get/get.go
+++ b/api/pkg/cli/cmd/get/get.go
@@ -15,6 +15,7 @@
 package get
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -125,6 +126,11 @@ func (opts *options) run() error {
 }
 
 func (opts *options) validate() error {
+	// Todo: support get sub command for artifact type
+	if opts.cli.Hub().GetType() == hub.ArtifactHubType {
+		return fmt.Errorf("get sub command is not supported for artifact type")
+	}
+
 	return flag.ValidateVersion(opts.version)
 }
 

--- a/api/pkg/cli/cmd/get/get_test.go
+++ b/api/pkg/cli/cmd/get/get_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/tektoncd/hub/api/pkg/cli/app"
+	"github.com/tektoncd/hub/api/pkg/cli/hub"
 	"github.com/tektoncd/hub/api/pkg/cli/test"
 	res "github.com/tektoncd/hub/api/v1/gen/resource"
 	goa "goa.design/goa/v3/pkg"
@@ -76,22 +78,35 @@ Get a Abc of name 'foo' of version '0.3':
 `
 
 func TestValidate(t *testing.T) {
+	cli := app.New()
+	if err := cli.SetHub(hub.TektonHubType); err != nil {
+		assert.Error(t, err)
+	}
+
 	opt := options{
 		version: "0.1",
+		cli:     cli,
 	}
 	err := opt.validate()
 	assert.NoError(t, err)
 
 	opt = options{
 		version: "0.3.1",
+		cli:     cli,
 	}
 	err = opt.validate()
 	assert.NoError(t, err)
 }
 
 func TestValidate_ErrorCase(t *testing.T) {
+	cli := app.New()
+	if err := cli.SetHub(hub.TektonHubType); err != nil {
+		assert.Error(t, err)
+	}
+
 	opt := options{
 		version: "abc",
+		cli:     cli,
 	}
 	err := opt.validate()
 	assert.EqualError(t, err, "invalid value \"abc\" set for option version. valid eg. 0.1, 1.2.1")

--- a/api/pkg/cli/cmd/info/info.go
+++ b/api/pkg/cli/cmd/info/info.go
@@ -15,6 +15,7 @@
 package info
 
 import (
+	"fmt"
 	"strings"
 	"text/template"
 
@@ -228,6 +229,11 @@ func (opts *options) run() error {
 }
 
 func (opts *options) validate() error {
+	// Todo: support info sub command for artifact type
+	if opts.cli.Hub().GetType() == hub.ArtifactHubType {
+		return fmt.Errorf("info sub command is not supported for artifact type")
+	}
+
 	return flag.ValidateVersion(opts.version)
 }
 

--- a/api/pkg/cli/cmd/install/install.go
+++ b/api/pkg/cli/cmd/install/install.go
@@ -184,6 +184,11 @@ func msg(res *unstructured.Unstructured) string {
 }
 
 func (opts *options) validate() error {
+	// Todo: support install sub command for artifact type
+	if opts.cli.Hub().GetType() == hub.ArtifactHubType {
+		return fmt.Errorf("install sub command is not supported for artifact type")
+	}
+
 	return flag.ValidateVersion(opts.version)
 }
 

--- a/api/pkg/cli/cmd/reinstall/reinstall.go
+++ b/api/pkg/cli/cmd/reinstall/reinstall.go
@@ -172,6 +172,11 @@ func msg(res *unstructured.Unstructured) string {
 }
 
 func (opts *options) validate() error {
+	// Todo: support reinstall sub command for artifact type
+	if opts.cli.Hub().GetType() == hub.ArtifactHubType {
+		return fmt.Errorf("reinstall sub command is not supported for artifact type")
+	}
+
 	return flag.ValidateVersion(opts.version)
 }
 

--- a/api/pkg/cli/cmd/search/search.go
+++ b/api/pkg/cli/cmd/search/search.go
@@ -158,6 +158,10 @@ func (opts *options) run() error {
 }
 
 func (opts *options) validate() error {
+	// Todo: support search sub command for artifact type
+	if opts.cli.Hub().GetType() == hub.ArtifactHubType {
+		return fmt.Errorf("search sub command is not supported for artifact type")
+	}
 
 	if flag.AllEmpty(opts.args, opts.kinds, opts.tags, opts.categories, opts.platforms) {
 		return fmt.Errorf("please specify a resource name, --tags, --platforms, --categories or --kinds flag to search")

--- a/api/pkg/cli/cmd/search/search_test.go
+++ b/api/pkg/cli/cmd/search/search_test.go
@@ -20,8 +20,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	res "github.com/tektoncd/hub/api/v1/gen/resource"
+	"github.com/tektoncd/hub/api/pkg/cli/app"
+	"github.com/tektoncd/hub/api/pkg/cli/hub"
 	"github.com/tektoncd/hub/api/pkg/cli/test"
+	res "github.com/tektoncd/hub/api/v1/gen/resource"
 	goa "goa.design/goa/v3/pkg"
 	"gopkg.in/h2non/gock.v1"
 	"gotest.tools/v3/golden"
@@ -91,11 +93,17 @@ var res2 = &res.ResourceData{
 }
 
 func TestValidate(t *testing.T) {
+	cli := app.New()
+	if err := cli.SetHub(hub.TektonHubType); err != nil {
+		assert.Error(t, err)
+	}
+
 	opt := options{
 		kinds:  []string{"pipeline"},
 		tags:   []string{"abc,def", "mno"},
 		match:  "exact",
 		output: "table",
+		cli:    cli,
 	}
 
 	err := opt.validate()
@@ -105,6 +113,7 @@ func TestValidate(t *testing.T) {
 		args:   []string{"abc"},
 		match:  "contains",
 		output: "json",
+		cli:    cli,
 	}
 
 	err = opt.validate()
@@ -113,7 +122,12 @@ func TestValidate(t *testing.T) {
 
 func TestValidate_ErrorCases(t *testing.T) {
 
-	opt := options{}
+	cli := app.New()
+	if err := cli.SetHub(hub.TektonHubType); err != nil {
+		assert.Error(t, err)
+	}
+
+	opt := options{cli: cli}
 	err := opt.validate()
 	assert.Error(t, err)
 	assert.EqualError(t, err, "please specify a resource name, --tags, --platforms, --categories or --kinds flag to search")
@@ -122,6 +136,7 @@ func TestValidate_ErrorCases(t *testing.T) {
 		kinds:  []string{"abc"},
 		match:  "exact",
 		output: "table",
+		cli:    cli,
 	}
 	err = opt.validate()
 	assert.Error(t, err)
@@ -131,6 +146,7 @@ func TestValidate_ErrorCases(t *testing.T) {
 		kinds:  []string{"task"},
 		match:  "abc",
 		output: "table",
+		cli:    cli,
 	}
 	err = opt.validate()
 	assert.Error(t, err)
@@ -140,6 +156,7 @@ func TestValidate_ErrorCases(t *testing.T) {
 		kinds:  []string{"task"},
 		match:  "exact",
 		output: "abc",
+		cli:    cli,
 	}
 	err = opt.validate()
 	assert.Error(t, err)

--- a/api/pkg/cli/cmd/upgrade/upgrade.go
+++ b/api/pkg/cli/cmd/upgrade/upgrade.go
@@ -187,6 +187,11 @@ func msg(res *unstructured.Unstructured) string {
 }
 
 func (opts *options) validate() error {
+	// Todo: support upgrade sub command for artifact type
+	if opts.cli.Hub().GetType() == hub.ArtifactHubType {
+		return fmt.Errorf("upgrade sub command is not supported for artifact type")
+	}
+
 	return flag.ValidateVersion(opts.version)
 }
 

--- a/api/pkg/cli/hub/get_catalog_test.go
+++ b/api/pkg/cli/hub/get_catalog_test.go
@@ -21,7 +21,5 @@ import (
 )
 
 func TestGetCatalogEndpoint(t *testing.T) {
-	url := catalogEndpoint()
-	assert.Equal(t, "/v1/catalogs", url)
-
+	assert.Equal(t, "/v1/catalogs", tektonHubCatEndpoint)
 }

--- a/api/pkg/cli/hub/get_resource.go
+++ b/api/pkg/cli/hub/get_resource.go
@@ -72,9 +72,15 @@ type ResourceWithVersionData = rclient.ResourceVersionDataResponseBody
 
 type resourceYaml = rclient.ByCatalogKindNameVersionYamlResponseBody
 
-// GetResource queries the data using Hub Endpoint
-func (c *client) GetResource(opt ResourceOption) ResourceResult {
-	data, status, err := c.Get(opt.Endpoint())
+// GetResource queries the data using Artifact Hub Endpoint
+func (a *artifactHubClient) GetResource(opt ResourceOption) ResourceResult {
+	// Todo: implement GetResource for Artifact Hub
+	return ResourceResult{}
+}
+
+// GetResource queries the data using Tekton Hub Endpoint
+func (t *tektonHubclient) GetResource(opt ResourceOption) ResourceResult {
+	data, status, err := t.Get(opt.Endpoint())
 
 	return ResourceResult{
 		data:    data,
@@ -85,11 +91,17 @@ func (c *client) GetResource(opt ResourceOption) ResourceResult {
 	}
 }
 
-// GetResource queries the data using Hub Endpoint
-func (c *client) GetResourceYaml(opt ResourceOption) ResourceResult {
+// GetResource queries the data using Artifact Hub Endpoint
+func (a *artifactHubClient) GetResourceYaml(opt ResourceOption) ResourceResult {
+	// Todo: implement GetResourceYaml for Artifact Hub
+	return ResourceResult{}
+}
 
-	yaml, yamlStatus, yamlErr := c.Get(fmt.Sprintf("/v1/resource/%s/%s/%s/%s/yaml", opt.Catalog, opt.Kind, opt.Name, opt.Version))
-	data, status, err := c.Get(opt.Endpoint())
+// GetResource queries the data using Tekton Hub Endpoint
+func (t *tektonHubclient) GetResourceYaml(opt ResourceOption) ResourceResult {
+
+	yaml, yamlStatus, yamlErr := t.Get(fmt.Sprintf("/v1/resource/%s/%s/%s/%s/yaml", opt.Catalog, opt.Kind, opt.Name, opt.Version))
+	data, status, err := t.Get(opt.Endpoint())
 
 	return ResourceResult{
 		data:       data,
@@ -243,9 +255,14 @@ func (rr *ResourceResult) MinPipelinesVersion() (string, error) {
 	return *rr.resourceData.LatestVersion.MinPipelinesVersion, nil
 }
 
-func (hubClient *client) GetResourcesList(so SearchOption) ([]string, error) {
+func (a *artifactHubClient) GetResourcesList(so SearchOption) ([]string, error) {
+	// Todo: implement GetResourcesList for Artifact Hub
+	return []string{}, nil
+}
+
+func (t *tektonHubclient) GetResourcesList(so SearchOption) ([]string, error) {
 	// Get all resources
-	result := hubClient.Search(SearchOption{
+	result := t.Search(SearchOption{
 		Kinds:   so.Kinds,
 		Catalog: so.Catalog,
 	})
@@ -270,10 +287,15 @@ func (hubClient *client) GetResourcesList(so SearchOption) ([]string, error) {
 	return resources, nil
 }
 
-func (hubClient *client) GetResourceVersionslist(r ResourceOption) ([]string, error) {
+func (a *artifactHubClient) GetResourceVersionslist(r ResourceOption) ([]string, error) {
+	// Todo: implement GetResourceVersionslist for Artifact Hub
+	return []string{}, nil
+}
+
+func (t *tektonHubclient) GetResourceVersionslist(r ResourceOption) ([]string, error) {
 	opts := &ResourceVersionOptions{}
 	// Get the resource versions
-	opts.hubResVersionsRes = hubClient.GetResourceVersions(ResourceOption{
+	opts.hubResVersionsRes = t.GetResourceVersions(ResourceOption{
 		Name:    r.Name,
 		Catalog: r.Catalog,
 		Kind:    r.Kind,

--- a/api/pkg/cli/hub/get_resource_version.go
+++ b/api/pkg/cli/hub/get_resource_version.go
@@ -38,12 +38,18 @@ type ResourceVersionResult struct {
 	versions *ResVersions
 }
 
-// GetResourceVersion queries the data using Hub Endpoint
-func (c *client) GetResourceVersions(opt ResourceOption) ResourceVersionResult {
+// GetResourceVersion queries the data using Artifact Hub Endpoint
+func (a *artifactHubClient) GetResourceVersions(opt ResourceOption) ResourceVersionResult {
+	// Todo: implement GetResourceVersions for Artifact Hub
+	return ResourceVersionResult{}
+}
+
+// GetResourceVersion queries the data using Tekton Hub Endpoint
+func (t *tektonHubclient) GetResourceVersions(opt ResourceOption) ResourceVersionResult {
 
 	rvr := ResourceVersionResult{set: false}
 
-	rvr.rr = c.GetResource(opt)
+	rvr.rr = t.GetResource(opt)
 	if rvr.err = rvr.rr.unmarshalData(); rvr.err != nil {
 		return rvr
 	}
@@ -55,7 +61,7 @@ func (c *client) GetResourceVersions(opt ResourceOption) ResourceVersionResult {
 		resID = *rvr.rr.resourceData.ID
 	}
 
-	rvr.data, rvr.status, rvr.err = c.Get(resVersionsEndpoint(resID))
+	rvr.data, rvr.status, rvr.err = t.Get(resVersionsEndpoint(resID))
 
 	return rvr
 }

--- a/api/pkg/cli/hub/hub_test.go
+++ b/api/pkg/cli/hub/hub_test.go
@@ -6,22 +6,43 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSetURL(t *testing.T) {
-
-	hub := &client{}
-	err := hub.SetURL("http://localhost:80000")
+func TestSetURL_TektonHub(t *testing.T) {
+	tHub := &tektonHubclient{}
+	err := tHub.SetURL("http://localhost:80000")
 	assert.NoError(t, err)
 
-	err = hub.SetURL("localhost:8000")
+	err = tHub.SetURL("localhost:8000")
 	assert.NoError(t, err)
 
-	err = hub.SetURL("http://80.80.79.9:80")
+	err = tHub.SetURL("http://80.80.79.9:80")
 	assert.NoError(t, err)
+
+	// default url
+	err = tHub.SetURL("")
+	assert.NoError(t, err)
+	assert.Equal(t, tHub.apiURL, tektonHubURL)
+}
+
+func TestSetURL_ArtifactHub(t *testing.T) {
+	aHub := &artifactHubClient{}
+	err := aHub.SetURL("http://localhost:80000")
+	assert.NoError(t, err)
+
+	err = aHub.SetURL("localhost:8000")
+	assert.NoError(t, err)
+
+	err = aHub.SetURL("http://80.80.79.9:80")
+	assert.NoError(t, err)
+
+	// default url
+	err = aHub.SetURL("")
+	assert.NoError(t, err)
+	assert.Equal(t, aHub.apiURL, artifactHubURL)
 }
 
 func TestSetURL_InvalidCase(t *testing.T) {
 
-	hub := &client{}
+	hub := &tektonHubclient{}
 	err := hub.SetURL("abc")
 	assert.Error(t, err)
 	assert.EqualError(t, err, "parse \"abc\": invalid URI for request")

--- a/api/pkg/cli/hub/search.go
+++ b/api/pkg/cli/hub/search.go
@@ -49,13 +49,25 @@ type SearchResult struct {
 	err       error
 }
 
-// Search queries the data using Hub Endpoint
-func (h *client) Search(so SearchOption) SearchResult {
-	data, status, err := h.Get(so.Endpoint())
+// Search queries the data using Artifact Hub Endpoint
+func (a *artifactHubClient) Search(so SearchOption) SearchResult {
+	// Todo: implement Search for Artifact Hub
+	return SearchResult{}
+}
+
+// Search queries the data using TektonHub Endpoint
+func (t *tektonHubclient) Search(so SearchOption) SearchResult {
+	data, status, err := t.Get(so.Endpoint())
 	if status == http.StatusNotFound {
 		err = nil
 	}
 	return SearchResult{data: data, status: status, err: err}
+}
+
+// Search queries the data using Hub Endpoint
+func (h *artifactHubCatalogResponse) Search(so SearchOption) SearchResult {
+	// todo: implement Search function for Artifact Hub
+	return SearchResult{}
 }
 
 // Raw returns API response as byte array

--- a/api/pkg/cli/test/config.go
+++ b/api/pkg/cli/test/config.go
@@ -33,7 +33,7 @@ type cli struct {
 var _ app.CLI = (*cli)(nil)
 
 func NewCLI() *cli {
-	h := hub.NewClient()
+	h := hub.NewTektonHubClient()
 	if err := h.SetURL(API); err != nil {
 		fmt.Printf("Failed validate and set the hub apiURL server URL %v", err)
 	}
@@ -54,4 +54,16 @@ func (c *cli) SetStream(out, err io.Writer) {
 
 func (c *cli) Hub() hub.Client {
 	return c.hub
+}
+
+func (c *cli) SetHub(hubType string) error {
+	if hubType == hub.TektonHubType {
+		c.hub = hub.NewTektonHubClient()
+		return nil
+	} else if hubType == hub.ArtifactHubType {
+		c.hub = hub.NewArtifactHubClient()
+		return nil
+	}
+
+	return fmt.Errorf("invalid hub type: %s", hubType)
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Part of https://github.com/tektoncd/hub/issues/691. The Hub CLI is used as a sub command `tkn hub` in https://github.com/tektoncd/cli. Prior to this change, the Hub CLI only supports to fetch catalog resources from Tekton Hub. This commit introduces a new flag `type`specifying the type of Hub to pull the resources from. The value can be set to either `artifact` or `tekton`. When setting to `artifact`, the CLI fetches resources from the Artifact Hub; when setting to `tekton`, the CLI fetches resources from the Tekton Hub.

The implementation for fetching resources from Artifact Hub will come in the following PRs.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Run API Unit Tests, Lint Checks, API Design, Golden Files with `make api-check`
- [ ] Run UI Unit Tests, Lint Checks with `make ui-check`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._
