### PR TITLE
Fixes to show api down error message on UI

### DIFF
--- a/ui/src/containers/Resources/index.tsx
+++ b/ui/src/containers/Resources/index.tsx
@@ -92,7 +92,9 @@ const Resources: React.FC = observer(() => {
           }`}
         />
         <Title headingLevel="h2" className="hub-resource-waring__margin">
-          {catalogs.err === catalogConfigureError && resources.err !== apiDownError
+          {resources.networkErr == true
+            ? apiDownError
+            : catalogs.err === catalogConfigureError && resources.err !== apiDownError
             ? catalogs.err
             : resources.err}
         </Title>

--- a/ui/src/store/resource.ts
+++ b/ui/src/store/resource.ts
@@ -134,6 +134,7 @@ export const ResourceStore = types
     tagsString: '',
     urlParams: '',
     err: '',
+    networkErr: true,
     isLoading: true,
     isVersionLoading: true,
     isResourceLoading: true,
@@ -298,6 +299,8 @@ export const ResourceStore = types
         const { api } = self;
 
         const json = yield api.resources();
+
+        self.networkErr = false;
         switch (true) {
           case json.data === undefined:
             self.status = 503;


### PR DESCRIPTION
Earlier it was showing catalog configure error
message when api was not reachable

Signed-off-by: Shiv Verma <shverma@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Before fixes: 
![Screenshot from 2022-11-07 12-56-53](https://user-images.githubusercontent.com/31416465/200250664-7c3648e8-31f4-43df-b006-460bbb8daadc.png)



After fixes: 
![Screenshot from 2022-11-07 12-32-51](https://user-images.githubusercontent.com/31416465/200250242-18002f25-acb4-4fb4-844c-1dfd16d47d22.png)


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Run API Unit Tests, Lint Checks, API Design, Golden Files with `make api-check`
- [x] Run UI Unit Tests, Lint Checks with `make ui-check`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._
