### PR TITLE
Implement "install" command for artifact type

### DIFF
--- a/api/pkg/cli/cmd/check_upgrade/check_upgrade_test.go
+++ b/api/pkg/cli/cmd/check_upgrade/check_upgrade_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/tektoncd/hub/api/pkg/cli/hub"
 	"github.com/tektoncd/hub/api/pkg/cli/test"
 	cb "github.com/tektoncd/hub/api/pkg/cli/test/builder"
 	res "github.com/tektoncd/hub/api/v1/gen/resource"
@@ -65,7 +66,7 @@ var resVersion = &res.ResourceData{
 }
 
 func TestUpdateAvailable(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -114,7 +115,7 @@ func TestUpdateAvailable(t *testing.T) {
 }
 
 func TestUpdateAvailable_WithSkippedTasks(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -173,7 +174,7 @@ func TestUpdateAvailable_WithSkippedTasks(t *testing.T) {
 }
 
 func TestNoUpdateAvailable(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -222,7 +223,7 @@ func TestNoUpdateAvailable(t *testing.T) {
 }
 
 func TestNoUpdateAvailable_TaskNotInstalledViaHubCLI(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -270,7 +271,7 @@ func TestNoUpdateAvailable_TaskNotInstalledViaHubCLI(t *testing.T) {
 }
 
 func TestUpdateAvailable_PipelinesUnknown(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -313,7 +314,7 @@ func TestUpdateAvailable_PipelinesUnknown(t *testing.T) {
 }
 
 func TestUpdateAvailable_WithSkippedTasks_PipelinesUnknown(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 

--- a/api/pkg/cli/cmd/downgrade/downgrade_test.go
+++ b/api/pkg/cli/cmd/downgrade/downgrade_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/tektoncd/hub/api/pkg/cli/hub"
 	"github.com/tektoncd/hub/api/pkg/cli/test"
 	cb "github.com/tektoncd/hub/api/pkg/cli/test/builder"
 	res "github.com/tektoncd/hub/api/v1/gen/resource"
@@ -111,7 +112,7 @@ var taskWitholdVersionYaml = &res.ResourceContent{
 }
 
 func TestDowngrade_ResourceNotExist(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	version := "v1beta1"
 	dynamic := test.DynamicClient()
@@ -132,7 +133,7 @@ func TestDowngrade_ResourceNotExist(t *testing.T) {
 }
 
 func TestDowngrade_VersionCatalogMissing(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	existingTask := &v1beta1.Task{
 		ObjectMeta: metav1.ObjectMeta{
@@ -160,7 +161,7 @@ func TestDowngrade_VersionCatalogMissing(t *testing.T) {
 }
 
 func TestDowngrade_VersionMissing(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	existingTask := &v1beta1.Task{
 		ObjectMeta: metav1.ObjectMeta{
@@ -189,7 +190,7 @@ func TestDowngrade_VersionMissing(t *testing.T) {
 }
 
 func TestDowngrade(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -256,7 +257,7 @@ func TestDowngrade(t *testing.T) {
 }
 
 func TestDowngrade_ToSpecificVersion(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -324,7 +325,7 @@ func TestDowngrade_ToSpecificVersion(t *testing.T) {
 }
 
 func TestDowngrade_SameVersionError(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -389,7 +390,7 @@ func TestDowngrade_SameVersionError(t *testing.T) {
 }
 
 func TestDowngrade_HigherVersionError(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -439,7 +440,7 @@ func TestDowngrade_HigherVersionError(t *testing.T) {
 }
 
 func TestDowngrade_ToSpecificVersionRespectingPipelinesVersionSuccess(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -511,7 +512,7 @@ func TestDowngrade_ToSpecificVersionRespectingPipelinesVersionSuccess(t *testing
 }
 
 func TestDowngrade_ToSpecificVersionRespectingPipelinesVersionFailure(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 

--- a/api/pkg/cli/cmd/get/get_test.go
+++ b/api/pkg/cli/cmd/get/get_test.go
@@ -113,7 +113,7 @@ func TestValidate_ErrorCase(t *testing.T) {
 }
 
 func TestGetResource_WithNewVersion(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -145,7 +145,7 @@ func TestGetResource_WithNewVersion(t *testing.T) {
 }
 
 func TestGetResource_WithOldVersion(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -176,7 +176,7 @@ func TestGetResource_WithOldVersion(t *testing.T) {
 }
 
 func TestGet_ResourceNotFound(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 

--- a/api/pkg/cli/cmd/get/task_test.go
+++ b/api/pkg/cli/cmd/get/task_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/tektoncd/hub/api/pkg/cli/hub"
 	"github.com/tektoncd/hub/api/pkg/cli/test"
 	res "github.com/tektoncd/hub/api/v1/gen/resource"
 	"gopkg.in/h2non/gock.v1"
@@ -63,7 +64,7 @@ var taskWithOldVersionYaml = &res.ResourceContent{
 }
 
 func TestGetTask_WithNewVersion(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -96,7 +97,7 @@ func TestGetTask_WithNewVersion(t *testing.T) {
 }
 
 func TestGetTask_AsClusterTask(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 

--- a/api/pkg/cli/cmd/info/info_test.go
+++ b/api/pkg/cli/cmd/info/info_test.go
@@ -20,8 +20,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	res "github.com/tektoncd/hub/api/v1/gen/resource"
+	"github.com/tektoncd/hub/api/pkg/cli/hub"
 	"github.com/tektoncd/hub/api/pkg/cli/test"
+	res "github.com/tektoncd/hub/api/v1/gen/resource"
 	"gopkg.in/h2non/gock.v1"
 	"gotest.tools/v3/golden"
 )
@@ -140,7 +141,7 @@ func mockApi(io InfoOptions, taskWithVersion *res.ResourceVersionData) {
 }
 
 func TestInfoTask_WithLatestVersion(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -170,7 +171,7 @@ func TestInfoTask_WithLatestVersion(t *testing.T) {
 }
 
 func TestInfoTask_WithOldVersion(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -200,7 +201,7 @@ func TestInfoTask_WithOldVersion(t *testing.T) {
 }
 
 func TestPipelineTask_MultiLineDescription(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 

--- a/api/pkg/cli/cmd/install/install.go
+++ b/api/pkg/cli/cmd/install/install.go
@@ -58,6 +58,8 @@ or
 Install a %S of name 'foo' of version '0.3' from Catalog 'Tekton':
 
     tkn hub install %s foo --version 0.3 --from tekton
+
+Note that the resources in Artifact Hub follow full SemVer - <major>.<minor>.<patch> (e.g. 0.3.0), please double check the version used
 `
 
 func Command(cli app.CLI) *cobra.Command {
@@ -184,11 +186,6 @@ func msg(res *unstructured.Unstructured) string {
 }
 
 func (opts *options) validate() error {
-	// Todo: support install sub command for artifact type
-	if opts.cli.Hub().GetType() == hub.ArtifactHubType {
-		return fmt.Errorf("install sub command is not supported for artifact type")
-	}
-
 	return flag.ValidateVersion(opts.version)
 }
 
@@ -222,8 +219,16 @@ func (opts *options) errors(pipelinesVersion string, errors []error) error {
 	for _, err := range errors {
 		if err == installer.ErrAlreadyExist {
 			existingVersion, ok := opts.resource.GetLabels()[versionLabel]
-			if ok {
 
+			// if version uses simple SemVer(<major>.<minor>), convert it to full SemVer (<major>.<minor>.<patch>)for comparison
+			if len(strings.Split(existingVersion, ".")) == 2 {
+				existingVersion += ".0"
+			}
+			if len(strings.Split(resourceVersion, ".")) == 2 {
+				resourceVersion += ".0"
+			}
+
+			if ok {
 				switch {
 				case existingVersion == resourceVersion:
 					return fmt.Errorf("%s %s(%s) already exists in %s namespace. Use reinstall command to overwrite existing",

--- a/api/pkg/cli/cmd/install/install_test.go
+++ b/api/pkg/cli/cmd/install/install_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/tektoncd/hub/api/pkg/cli/hub"
 	"github.com/tektoncd/hub/api/pkg/cli/test"
 	cb "github.com/tektoncd/hub/api/pkg/cli/test/builder"
 	res "github.com/tektoncd/hub/api/v1/gen/resource"
@@ -99,90 +100,148 @@ var taskWithOldVersionYaml = &res.ResourceContent{
 	Yaml: &task2,
 }
 
-func TestInstall_NewResource(t *testing.T) {
-	cli := test.NewCLI()
-
-	defer gock.Off()
-
-	rVer := &res.ResourceVersionYaml{Data: taskWithNewVersionYaml}
-	resWithVersion := res.NewViewedResourceVersionYaml(rVer, "default")
-
-	resInfo := fmt.Sprintf("%s/%s/%s/%s", "tekton", "task", "foo", "0.3")
-
-	gock.New(test.API).
-		Get("/resource/" + resInfo + "/yaml").
-		Reply(200).
-		JSON(&resWithVersion.Projected)
-
-	resVersion := &res.ResourceVersion{Data: resVersion}
-	resource := res.NewViewedResourceVersion(resVersion, "default")
-	gock.New(test.API).
-		Get("/resource/tekton/task/foo/0.3").
-		Reply(200).
-		JSON(&resource.Projected)
-
-	buf := new(bytes.Buffer)
+func prepareOpts(t *testing.T, buf *bytes.Buffer, hubType, from, version string) *options {
+	cli := test.NewCLI(hubType)
 	cli.SetStream(buf, buf)
 
-	version := "v1beta1"
 	dynamic := test.DynamicClient()
-
 	cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{})
-	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"task"})
+	cs.Pipeline.Resources = cb.APIResourceList("v1beta1", []string{"task"})
 
-	opts := &options{
+	return &options{
 		cs:      test.FakeClientSet(cs.Pipeline, dynamic, "hub"),
 		cli:     cli,
 		kind:    "task",
 		args:    []string{"foo"},
-		from:    "tekton",
-		version: "0.3",
+		from:    from,
+		version: version,
 	}
-
-	err := opts.run()
-	assert.NoError(t, err)
-	assert.Equal(t, "WARN: tekton pipelines version unknown, this resource is compatible with pipelines min version v0.12\nTask foo(0.3) installed in hub namespace\n", buf.String())
-	assert.Equal(t, gock.IsDone(), true)
 }
 
-func TestInstall_ResourceNotFoundInHub(t *testing.T) {
-	cli := test.NewCLI()
+func TestInstall_NewResource(t *testing.T) {
+	t.Run("TestInstall_NewResource_TektonHub", func(t *testing.T) {
+		defer gock.Off()
 
-	defer gock.Off()
+		rVer := &res.ResourceVersionYaml{Data: taskWithNewVersionYaml}
+		resWithVersion := res.NewViewedResourceVersionYaml(rVer, "default")
+		resInfo := fmt.Sprintf("%s/%s/%s/%s", "tekton", "task", "foo", "0.3")
+		gock.New(test.API).
+			Get("/resource/" + resInfo + "/yaml").
+			Reply(200).
+			JSON(&resWithVersion.Projected)
 
-	gock.New(test.API).
-		Get("/resource/tekton/task/foo/0.3/yaml").
-		Reply(404).
-		JSON(&goa.ServiceError{
-			ID:      "123456",
-			Name:    "not-found",
-			Message: "resource not found",
-		})
+		resVersion := &res.ResourceVersion{Data: resVersion}
+		resource := res.NewViewedResourceVersion(resVersion, "default")
+		gock.New(test.API).
+			Get("/resource/tekton/task/foo/0.3").
+			Reply(200).
+			JSON(&resource.Projected)
 
-	gock.New(test.API).
-		Get("/resource/tekton/task/foo/0.3").
-		Reply(404).
-		JSON(&goa.ServiceError{
-			ID:      "123456",
-			Name:    "not-found",
-			Message: "resource not found",
-		})
+		buf := new(bytes.Buffer)
+		from := "tekton"
+		version := "0.3"
+		opts := prepareOpts(t, buf, hub.TektonHubType, from, version)
 
-	opts := &options{
-		cli:     cli,
-		kind:    "task",
-		args:    []string{"foo"},
-		from:    "tekton",
-		version: "0.3",
+		err := opts.run()
+		assert.NoError(t, err)
+		assert.Equal(t, "WARN: tekton pipelines version unknown, this resource is compatible with pipelines min version v0.12\nTask foo(0.3) installed in hub namespace\n", buf.String())
+		assert.Equal(t, gock.IsDone(), true)
+	})
+
+	t.Run("TestInstall_NewResource_ArtifactHub", func(t *testing.T) {
+		defer gock.Off()
+
+		from := "tekton-catalog-tasks"
+		task := "foo"
+		version := "0.3.0"
+		ahPkgData := hub.PkgData{
+			ManifestRaw:    task1,
+			PipelineMinVer: "0.12",
+		}
+		ahPkg := hub.ArtifactHubPkgResponse{Data: ahPkgData}
+		resInfo := fmt.Sprintf("%s-%s/%s/%s/%s", "/api/v1/packages/tekton", "task", from, task, version)
+
+		gock.New(test.API).
+			Get(resInfo).
+			Reply(200).
+			JSON(&ahPkg)
+
+		buf := new(bytes.Buffer)
+		opts := prepareOpts(t, buf, hub.ArtifactHubType, from, version)
+
+		err := opts.run()
+
+		assert.NoError(t, err)
+		assert.Equal(t, "WARN: tekton pipelines version unknown, this resource is compatible with pipelines min version v0.12\nTask foo(0.3) installed in hub namespace\n", buf.String())
+		assert.Equal(t, gock.IsDone(), true)
+	})
+}
+
+func TestInstall_ResourceNotFound(t *testing.T) {
+	serviceErr := &goa.ServiceError{
+		ID:      "123456",
+		Name:    "not-found",
+		Message: "resource not found",
 	}
 
-	err := opts.run()
-	assert.Error(t, err)
-	assert.EqualError(t, err, "Task foo(0.3) from tekton catalog not found in Hub")
+	t.Run("TestInstall_ResourceNotFound_TektonHub", func(t *testing.T) {
+		cli := test.NewCLI(hub.TektonHubType)
+
+		defer gock.Off()
+
+		gock.New(test.API).
+			Get("/resource/tekton/task/foo/0.3/yaml").
+			Reply(404).
+			JSON(serviceErr)
+		gock.New(test.API).
+			Get("/resource/tekton/task/foo/0.3").
+			Reply(404).
+			JSON(serviceErr)
+
+		opts := &options{
+			cli:     cli,
+			kind:    "task",
+			args:    []string{"foo"},
+			from:    "tekton",
+			version: "0.3",
+		}
+
+		err := opts.run()
+		assert.Error(t, err)
+		assert.EqualError(t, err, "Task foo(0.3) from tekton catalog not found in Hub")
+	})
+
+	t.Run("TestInstall_ResourceNotFound_ArtifactHub", func(t *testing.T) {
+		cli := test.NewCLI(hub.ArtifactHubType)
+
+		defer gock.Off()
+
+		from := "tekton-catalog-tasks-not-exist"
+		task := "foo"
+		version := "0.3.0"
+		resInfo := fmt.Sprintf("%s-%s/%s/%s/%s", "/api/v1/packages/tekton", "task", from, task, version)
+
+		gock.New(test.API).
+			Get(resInfo).
+			Reply(404).
+			JSON(serviceErr)
+
+		opts := &options{
+			cli:     cli,
+			kind:    "task",
+			args:    []string{"foo"},
+			from:    from,
+			version: version,
+		}
+
+		err := opts.run()
+		assert.Error(t, err)
+		assert.EqualError(t, err, "Task foo(0.3.0) from tekton-catalog-tasks-not-exist catalog not found in Hub")
+	})
 }
 
 func TestInstall_ResourceAlreadyExistError(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -235,7 +294,7 @@ func TestInstall_ResourceAlreadyExistError(t *testing.T) {
 }
 
 func TestInstall_UpgradeError(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -284,12 +343,12 @@ func TestInstall_UpgradeError(t *testing.T) {
 
 	err := opts.run()
 	assert.Error(t, err)
-	assert.EqualError(t, err, "Task foo(0.1) already exists in hub namespace. Use upgrade command to install v0.3")
+	assert.EqualError(t, err, "Task foo(0.1.0) already exists in hub namespace. Use upgrade command to install v0.3.0")
 	assert.Equal(t, gock.IsDone(), true)
 }
 
 func TestInstall_SameVersionError(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -338,12 +397,12 @@ func TestInstall_SameVersionError(t *testing.T) {
 
 	err := opts.run()
 	assert.Error(t, err)
-	assert.EqualError(t, err, "Task foo(0.3) already exists in hub namespace. Use reinstall command to overwrite existing")
+	assert.EqualError(t, err, "Task foo(0.3.0) already exists in hub namespace. Use reinstall command to overwrite existing")
 	assert.Equal(t, gock.IsDone(), true)
 }
 
 func TestInstall_LowerVersionError(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -391,12 +450,12 @@ func TestInstall_LowerVersionError(t *testing.T) {
 
 	err := opts.run()
 	assert.Error(t, err)
-	assert.EqualError(t, err, "Task foo(0.7) already exists in hub namespace. Use downgrade command to install v0.3")
+	assert.EqualError(t, err, "Task foo(0.7.0) already exists in hub namespace. Use downgrade command to install v0.3.0")
 	assert.Equal(t, gock.IsDone(), true)
 }
 
 func TestInstall_RespectingPipelinesVersion(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -447,7 +506,7 @@ func TestInstall_RespectingPipelinesVersion(t *testing.T) {
 }
 
 func TestInstall_RespectingPipelinesVersionFailure(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -498,7 +557,7 @@ func TestInstall_RespectingPipelinesVersionFailure(t *testing.T) {
 }
 
 func TestInstall_DeprecatedVersion(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 

--- a/api/pkg/cli/cmd/reinstall/reinstall_test.go
+++ b/api/pkg/cli/cmd/reinstall/reinstall_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/tektoncd/hub/api/pkg/cli/hub"
 	"github.com/tektoncd/hub/api/pkg/cli/test"
 	cb "github.com/tektoncd/hub/api/pkg/cli/test/builder"
 	res "github.com/tektoncd/hub/api/v1/gen/resource"
@@ -78,7 +79,7 @@ var taskWithNewVersionYaml = &res.ResourceContent{
 }
 
 func TestReinstall_ResourceNotExist(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	version := "v1beta1"
 	dynamic := test.DynamicClient()
@@ -99,7 +100,7 @@ func TestReinstall_ResourceNotExist(t *testing.T) {
 }
 
 func TestReinstall_VersionCatalogMissing(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	existingTask := &v1beta1.Task{
 		ObjectMeta: metav1.ObjectMeta{
@@ -127,7 +128,7 @@ func TestReinstall_VersionCatalogMissing(t *testing.T) {
 }
 
 func TestReinstall_VersionMissing(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	existingTask := &v1beta1.Task{
 		ObjectMeta: metav1.ObjectMeta{
@@ -156,7 +157,7 @@ func TestReinstall_VersionMissing(t *testing.T) {
 }
 
 func TestReinstall_DifferentVersionPassedByFlag(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -210,7 +211,7 @@ func TestReinstall_DifferentVersionPassedByFlag(t *testing.T) {
 }
 
 func TestReinstall_DifferentCatalogPassedByFlag(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -267,7 +268,7 @@ func TestReinstall_DifferentCatalogPassedByFlag(t *testing.T) {
 }
 
 func TestReinstall(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -321,7 +322,7 @@ func TestReinstall(t *testing.T) {
 }
 
 func TestReinstall_RespectPipelinesVersionSuccess(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -379,7 +380,7 @@ func TestReinstall_RespectPipelinesVersionSuccess(t *testing.T) {
 }
 
 func TestReinstall_RespectPipelinesVersionFailure(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 

--- a/api/pkg/cli/cmd/search/search_test.go
+++ b/api/pkg/cli/cmd/search/search_test.go
@@ -164,7 +164,7 @@ func TestValidate_ErrorCases(t *testing.T) {
 }
 
 func TestSearch_TableFormat(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 	rArr := &res.Resources{Data: res.ResourceDataCollection{res1, res2}}
@@ -193,7 +193,7 @@ func TestSearch_TableFormat(t *testing.T) {
 
 // Updates golden file as GOA is unable to pick the min view of catalog
 func TestSearch_JSONFormat(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 	rArr := &res.Resources{Data: res.ResourceDataCollection{res2}}
@@ -221,7 +221,7 @@ func TestSearch_JSONFormat(t *testing.T) {
 }
 
 func TestSearch_ResourceNotFound(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -250,7 +250,7 @@ func TestSearch_ResourceNotFound(t *testing.T) {
 }
 
 func TestSearch_InternalServerError(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -280,7 +280,7 @@ func TestSearch_InternalServerError(t *testing.T) {
 }
 
 func TestSearch_InvalidAPIServerURL(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	err := cli.Hub().SetURL("api")
 	assert.Error(t, err)

--- a/api/pkg/cli/cmd/upgrade/upgrade_test.go
+++ b/api/pkg/cli/cmd/upgrade/upgrade_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/tektoncd/hub/api/pkg/cli/hub"
 	"github.com/tektoncd/hub/api/pkg/cli/test"
 	cb "github.com/tektoncd/hub/api/pkg/cli/test/builder"
 	res "github.com/tektoncd/hub/api/v1/gen/resource"
@@ -78,7 +79,7 @@ var taskWithNewVersionYaml = &res.ResourceContent{
 }
 
 func TestUpgrade_ResourceNotExist(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	version := "v1beta1"
 	dynamic := test.DynamicClient()
@@ -99,7 +100,7 @@ func TestUpgrade_ResourceNotExist(t *testing.T) {
 }
 
 func TestUpgrade_VersionCatalogMissing(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	existingTask := &v1beta1.Task{
 		ObjectMeta: metav1.ObjectMeta{
@@ -127,7 +128,7 @@ func TestUpgrade_VersionCatalogMissing(t *testing.T) {
 }
 
 func TestUpgrade_VersionMissing(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	existingTask := &v1beta1.Task{
 		ObjectMeta: metav1.ObjectMeta{
@@ -156,7 +157,7 @@ func TestUpgrade_VersionMissing(t *testing.T) {
 }
 
 func TestUpgrade_ToSpecificVersion(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -211,7 +212,7 @@ func TestUpgrade_ToSpecificVersion(t *testing.T) {
 }
 
 func TestUpgrade_SameVersionError(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -263,7 +264,7 @@ func TestUpgrade_SameVersionError(t *testing.T) {
 }
 
 func TestUpgrade_LowerVersionError(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -315,7 +316,7 @@ func TestUpgrade_LowerVersionError(t *testing.T) {
 }
 
 func TestUpgrade_ToSpecificVersion_RespectingPipelineSuccess(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -375,7 +376,7 @@ func TestUpgrade_ToSpecificVersion_RespectingPipelineSuccess(t *testing.T) {
 }
 
 func TestUpgrade_ToSpecificVersion_RespectingPipelineFailure(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 

--- a/api/pkg/cli/hub/get_catalog.go
+++ b/api/pkg/cli/hub/get_catalog.go
@@ -22,13 +22,6 @@ import (
 	cclient "github.com/tektoncd/hub/api/v1/gen/http/catalog/client"
 )
 
-const (
-	tektonHubCatEndpoint    = "/v1/catalogs"
-	artifactHubCatEndpoint  = "/api/v1/repositories/search"
-	artifactHubTaskType     = 7
-	artifactHubPipelineType = 11
-)
-
 type CatalogResult struct {
 	data    []byte
 	status  int
@@ -37,7 +30,7 @@ type CatalogResult struct {
 }
 type CatalogData = cclient.ListResponseBody
 
-type artifactHubCatalogResponse struct {
+type ArtifactHubCatalogResponse struct {
 	Name string `json:"name,omitempty"`
 }
 
@@ -64,12 +57,12 @@ func (cr *CatalogResult) Type() (CatalogData, error) {
 }
 
 func (a *artifactHubClient) GetCatalogsList() ([]string, error) {
-	data, _, err := a.Get(fmt.Sprintf("%s?kind=%v&kind=%v", artifactHubCatEndpoint, artifactHubTaskType, artifactHubPipelineType))
+	data, _, err := a.Get(fmt.Sprintf("%s?kind=%v&kind=%v", artifactHubCatSearchEndpoint, artifactHubTaskType, artifactHubPipelineType))
 	if err != nil {
 		return nil, err
 	}
 
-	resp := []artifactHubCatalogResponse{}
+	resp := []ArtifactHubCatalogResponse{}
 	err = json.Unmarshal(data, &resp)
 	if err != nil {
 		return nil, fmt.Errorf("error unmarshalling json response: %w", err)

--- a/api/pkg/cli/hub/hub.go
+++ b/api/pkg/cli/hub/hub.go
@@ -33,6 +33,12 @@ const (
 	tektonHubURL   = "https://api.hub.tekton.dev"
 	artifactHubURL = "https://artifacthub.io"
 	hubConfigPath  = ".tekton/hub-config"
+
+	tektonHubCatEndpoint         = "/v1/catalogs"
+	artifactHubCatSearchEndpoint = "/api/v1/repositories/search"
+	artifactHubCatInfoEndpoint   = "/api/v1/packages/tekton"
+	artifactHubTaskType          = 7
+	artifactHubPipelineType      = 11
 )
 
 type Client interface {

--- a/api/pkg/cli/hub/search.go
+++ b/api/pkg/cli/hub/search.go
@@ -65,7 +65,7 @@ func (t *tektonHubclient) Search(so SearchOption) SearchResult {
 }
 
 // Search queries the data using Hub Endpoint
-func (h *artifactHubCatalogResponse) Search(so SearchOption) SearchResult {
+func (h *ArtifactHubCatalogResponse) Search(so SearchOption) SearchResult {
 	// todo: implement Search function for Artifact Hub
 	return SearchResult{}
 }

--- a/api/pkg/cli/test/config.go
+++ b/api/pkg/cli/test/config.go
@@ -32,12 +32,21 @@ type cli struct {
 
 var _ app.CLI = (*cli)(nil)
 
-func NewCLI() *cli {
-	h := hub.NewTektonHubClient()
+func NewCLI(hubType string) *cli {
+	var h hub.Client
+	switch hubType {
+	case hub.TektonHubType:
+		h = hub.NewTektonHubClient()
+	case hub.ArtifactHubType:
+		h = hub.NewArtifactHubClient()
+	default:
+		fmt.Printf("invalid hub type: %s, using default type: %s to continue", hubType, hub.TektonHubType)
+		h = hub.NewTektonHubClient()
+	}
+
 	if err := h.SetURL(API); err != nil {
 		fmt.Printf("Failed validate and set the hub apiURL server URL %v", err)
 	}
-
 	return &cli{
 		stream: app.Stream{},
 		hub:    h,


### PR DESCRIPTION
Part of https://github.com/tektoncd/hub/issues/691. Prior to this commit, the `tkn hub install` command is only supported with `--type tekton`. This commit adds the `tkn hub install` functionality for `--type artifact`, which fetches resources from the Artifact Hub and install to user's cluster.

Example:
`tkn hub install task golang-build --from tekton-catalogs-task --version 0.2.0`

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Run API Unit Tests, Lint Checks, API Design, Golden Files with `make api-check`
- [ ] Run UI Unit Tests, Lint Checks with `make ui-check`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._
