### PR TITLE
Fixes user's id parsing in the user info api

### DIFF
--- a/api/pkg/user/service/user_test.go
+++ b/api/pkg/user/service/user_test.go
@@ -215,3 +215,11 @@ func TestNewRefreshToken_RefreshTokenChecksumIsDifferent(t *testing.T) {
 
 	assert.Equal(t, res.Body.String(), "invalid refresh token\n")
 }
+
+func TestParseStringToFloat(t *testing.T) {
+	got, err := ParseStringToFloat("1.123456789e+09")
+	want := 1123456789
+
+	assert.NoError(t, err)
+	assert.Equal(t, int(got), want)
+}


### PR DESCRIPTION
It fixes user's id parsing in the user info api
in case user id is in a scientific notation(e.g 1.23456789e+08)

Signed-off-by: Shiv Verma <shverma@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Run API Unit Tests, Lint Checks, API Design, Golden Files with `make api-check`
- [ ] Run UI Unit Tests, Lint Checks with `make ui-check`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._
