### PR TITLE
Refactor get_resource and get_resource_version for multiple hub support

### DIFF
--- a/api/pkg/cli/hub/get_resource.go
+++ b/api/pkg/cli/hub/get_resource.go
@@ -34,8 +34,18 @@ type ResourceOption struct {
 	PipelineVersion string
 }
 
-// ResourceResult defines API response
-type ResourceResult struct {
+type ResourceResult interface {
+	RawURL() (string, error)
+	Manifest() ([]byte, error)
+	Resource() (interface{}, error)
+	ResourceYaml() (string, error)
+	ResourceVersion() (string, error)
+	MinPipelinesVersion() (string, error)
+	UnmarshalData() error
+}
+
+// TektonHubResourceResult defines Tekton Hub API response
+type TektonHubResourceResult struct {
 	data                    []byte
 	yaml                    []byte
 	status                  int
@@ -47,6 +57,10 @@ type ResourceResult struct {
 	resourceData            *ResourceData
 	resourceWithVersionData *ResourceWithVersionData
 	ResourceContent         *ResourceContent
+}
+
+// ArtifactHubResourceResult defines Artifact Hub API response
+type ArtifactHubResourceResult struct {
 }
 
 type ResourceVersionOptions struct {
@@ -75,14 +89,14 @@ type resourceYaml = rclient.ByCatalogKindNameVersionYamlResponseBody
 // GetResource queries the data using Artifact Hub Endpoint
 func (a *artifactHubClient) GetResource(opt ResourceOption) ResourceResult {
 	// Todo: implement GetResource for Artifact Hub
-	return ResourceResult{}
+	return nil
 }
 
 // GetResource queries the data using Tekton Hub Endpoint
 func (t *tektonHubclient) GetResource(opt ResourceOption) ResourceResult {
 	data, status, err := t.Get(opt.Endpoint())
 
-	return ResourceResult{
+	return &TektonHubResourceResult{
 		data:    data,
 		version: opt.Version,
 		status:  status,
@@ -94,7 +108,7 @@ func (t *tektonHubclient) GetResource(opt ResourceOption) ResourceResult {
 // GetResource queries the data using Artifact Hub Endpoint
 func (a *artifactHubClient) GetResourceYaml(opt ResourceOption) ResourceResult {
 	// Todo: implement GetResourceYaml for Artifact Hub
-	return ResourceResult{}
+	return nil
 }
 
 // GetResource queries the data using Tekton Hub Endpoint
@@ -103,7 +117,7 @@ func (t *tektonHubclient) GetResourceYaml(opt ResourceOption) ResourceResult {
 	yaml, yamlStatus, yamlErr := t.Get(fmt.Sprintf("/v1/resource/%s/%s/%s/%s/yaml", opt.Catalog, opt.Kind, opt.Name, opt.Version))
 	data, status, err := t.Get(opt.Endpoint())
 
-	return ResourceResult{
+	return &TektonHubResourceResult{
 		data:       data,
 		yaml:       yaml,
 		version:    opt.Version,
@@ -113,146 +127,6 @@ func (t *tektonHubclient) GetResourceYaml(opt ResourceOption) ResourceResult {
 		yamlErr:    yamlErr,
 		set:        false,
 	}
-}
-
-// Endpoint computes the endpoint url using input provided
-func (opt ResourceOption) Endpoint() string {
-	if opt.Version != "" {
-		// API: /resource/<catalog>/<kind>/<name>/<version>
-		return fmt.Sprintf("/v1/resource/%s/%s/%s/%s", opt.Catalog, opt.Kind, opt.Name, opt.Version)
-	}
-	if opt.PipelineVersion != "" {
-		opt.PipelineVersion = strings.TrimLeft(opt.PipelineVersion, "v")
-		// API: /resource/<catalog>/<kind>/<name>?pipelinesversion=<version>
-		return fmt.Sprintf("/v1/resource/%s/%s/%s?pipelinesversion=%s", opt.Catalog, opt.Kind, opt.Name, opt.PipelineVersion)
-	}
-	// API: /resource/<catalog>/<kind>/<name>
-	return fmt.Sprintf("/v1/resource/%s/%s/%s", opt.Catalog, opt.Kind, opt.Name)
-}
-
-func (rr *ResourceResult) unmarshalData() error {
-	if rr.err != nil {
-		return rr.err
-	}
-	if rr.set {
-		return nil
-	}
-
-	if rr.status == http.StatusNotFound {
-		return fmt.Errorf("No Resource Found")
-	}
-
-	// API Response when version is not mentioned, will fetch latest by default
-	if rr.version == "" {
-		res := resResponse{}
-		if err := json.Unmarshal(rr.data, &res); err != nil {
-			return err
-		}
-		rr.resourceData = res.Data
-
-		rr.set = true
-		return nil
-	}
-
-	// API Response when a specific version is mentioned
-	res := resVersionResponse{}
-	if err := json.Unmarshal(rr.data, &res); err != nil {
-		return err
-	}
-	rr.resourceWithVersionData = res.Data
-	rr.set = true
-	return nil
-}
-
-// RawURL returns the raw url of the resource yaml file
-func (rr *ResourceResult) RawURL() (string, error) {
-	if err := rr.unmarshalData(); err != nil {
-		return "", err
-	}
-
-	if rr.version != "" {
-		return *rr.resourceWithVersionData.RawURL, nil
-	}
-	return *rr.resourceData.LatestVersion.RawURL, nil
-}
-
-// Manifest gets the resource from catalog
-func (rr *ResourceResult) Manifest() ([]byte, error) {
-	rawURL, err := rr.RawURL()
-	if err != nil {
-		return nil, err
-	}
-
-	data, status, err := httpGet(rawURL)
-
-	if err != nil {
-		return nil, err
-	}
-
-	if status != http.StatusOK {
-		return nil, fmt.Errorf("failed to fetch resource from catalog")
-	}
-
-	return data, nil
-}
-
-// Resource returns the resource found
-func (rr *ResourceResult) Resource() (interface{}, error) {
-	if err := rr.unmarshalData(); err != nil {
-		return "", err
-	}
-
-	if rr.version != "" {
-		return *rr.resourceWithVersionData, nil
-	}
-	return *rr.resourceData, nil
-}
-
-// Resource returns the resource found
-func (rr *ResourceResult) ResourceYaml() (string, error) {
-
-	if rr.yamlErr != nil {
-		return "", rr.err
-	}
-	if rr.set {
-		return "", nil
-	}
-
-	if rr.yamlStatus == http.StatusNotFound {
-		return "", fmt.Errorf("No Resource Found")
-	}
-
-	res := resourceYaml{}
-	if err := json.Unmarshal(rr.yaml, &res); err != nil {
-		return "", err
-	}
-	rr.ResourceContent = res.Data
-
-	return *rr.ResourceContent.Yaml, nil
-}
-
-// ResourceVersion returns the resource version found
-func (rr *ResourceResult) ResourceVersion() (string, error) {
-	if err := rr.unmarshalData(); err != nil {
-		return "", err
-	}
-
-	if rr.version != "" {
-		return *rr.resourceWithVersionData.Version, nil
-	}
-	return *rr.resourceData.LatestVersion.Version, nil
-}
-
-// MinPipelinesVersion returns the minimum pipeline version the resource is compatible
-func (rr *ResourceResult) MinPipelinesVersion() (string, error) {
-	if err := rr.unmarshalData(); err != nil {
-		return "", err
-	}
-
-	if rr.version != "" {
-		return *rr.resourceWithVersionData.MinPipelinesVersion, nil
-	}
-	return *rr.resourceData.LatestVersion.MinPipelinesVersion, nil
 }
 
 func (a *artifactHubClient) GetResourcesList(so SearchOption) ([]string, error) {
@@ -314,4 +188,185 @@ func (t *tektonHubclient) GetResourceVersionslist(r ResourceOption) ([]string, e
 	sort.Sort(sort.Reverse(sort.StringSlice(ver)))
 
 	return ver, nil
+}
+
+// Endpoint computes the endpoint url using input provided
+func (opt ResourceOption) Endpoint() string {
+	if opt.Version != "" {
+		// API: /resource/<catalog>/<kind>/<name>/<version>
+		return fmt.Sprintf("/v1/resource/%s/%s/%s/%s", opt.Catalog, opt.Kind, opt.Name, opt.Version)
+	}
+	if opt.PipelineVersion != "" {
+		opt.PipelineVersion = strings.TrimLeft(opt.PipelineVersion, "v")
+		// API: /resource/<catalog>/<kind>/<name>?pipelinesversion=<version>
+		return fmt.Sprintf("/v1/resource/%s/%s/%s?pipelinesversion=%s", opt.Catalog, opt.Kind, opt.Name, opt.PipelineVersion)
+	}
+	// API: /resource/<catalog>/<kind>/<name>
+	return fmt.Sprintf("/v1/resource/%s/%s/%s", opt.Catalog, opt.Kind, opt.Name)
+}
+
+func (rr *TektonHubResourceResult) UnmarshalData() error {
+	if rr.err != nil {
+		return rr.err
+	}
+	if rr.set {
+		return nil
+	}
+
+	if rr.status == http.StatusNotFound {
+		return fmt.Errorf("No Resource Found")
+	}
+
+	// API Response when version is not mentioned, will fetch latest by default
+	if rr.version == "" {
+		res := resResponse{}
+		if err := json.Unmarshal(rr.data, &res); err != nil {
+			return err
+		}
+		rr.resourceData = res.Data
+
+		rr.set = true
+		return nil
+	}
+
+	// API Response when a specific version is mentioned
+	res := resVersionResponse{}
+	if err := json.Unmarshal(rr.data, &res); err != nil {
+		return err
+	}
+	rr.resourceWithVersionData = res.Data
+	rr.set = true
+	return nil
+}
+
+func (rr *ArtifactHubResourceResult) UnmarshalData() error {
+	// TODO
+	return nil
+}
+
+// RawURL returns the raw url of the resource yaml file
+func (rr *TektonHubResourceResult) RawURL() (string, error) {
+	if err := rr.UnmarshalData(); err != nil {
+		return "", err
+	}
+
+	if rr.version != "" {
+		return *rr.resourceWithVersionData.RawURL, nil
+	}
+	return *rr.resourceData.LatestVersion.RawURL, nil
+}
+
+// RawURL returns the raw url of the resource yaml file
+func (rr *ArtifactHubResourceResult) RawURL() (string, error) {
+	// TODO
+	return "", nil
+}
+
+// Manifest gets the resource from catalog
+func (rr *TektonHubResourceResult) Manifest() ([]byte, error) {
+	rawURL, err := rr.RawURL()
+	if err != nil {
+		return nil, err
+	}
+
+	data, status, err := httpGet(rawURL)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if status != http.StatusOK {
+		return nil, fmt.Errorf("failed to fetch resource from catalog")
+	}
+
+	return data, nil
+}
+
+// Manifest gets the resource from catalog
+func (rr *ArtifactHubResourceResult) Manifest() ([]byte, error) {
+	// TODO
+	return []byte{}, nil
+}
+
+// Resource returns the resource found
+func (rr *TektonHubResourceResult) Resource() (interface{}, error) {
+	if err := rr.UnmarshalData(); err != nil {
+		return "", err
+	}
+
+	if rr.version != "" {
+		return *rr.resourceWithVersionData, nil
+	}
+	return *rr.resourceData, nil
+}
+
+// Resource returns the resource found
+func (rr *ArtifactHubResourceResult) Resource() (interface{}, error) {
+	// TODO
+	return "", nil
+}
+
+// Resource returns the resource found
+func (rr *TektonHubResourceResult) ResourceYaml() (string, error) {
+
+	if rr.yamlErr != nil {
+		return "", rr.err
+	}
+	if rr.set {
+		return "", nil
+	}
+
+	if rr.yamlStatus == http.StatusNotFound {
+		return "", fmt.Errorf("No Resource Found")
+	}
+
+	res := resourceYaml{}
+	if err := json.Unmarshal(rr.yaml, &res); err != nil {
+		return "", err
+	}
+	rr.ResourceContent = res.Data
+
+	return *rr.ResourceContent.Yaml, nil
+}
+
+// Resource returns the resource found
+func (rr *ArtifactHubResourceResult) ResourceYaml() (string, error) {
+	// TODO
+	return "", nil
+}
+
+// ResourceVersion returns the resource version found
+func (rr *TektonHubResourceResult) ResourceVersion() (string, error) {
+	if err := rr.UnmarshalData(); err != nil {
+		return "", err
+	}
+
+	if rr.version != "" {
+		return *rr.resourceWithVersionData.Version, nil
+	}
+	return *rr.resourceData.LatestVersion.Version, nil
+}
+
+// ResourceVersion returns the resource version found
+func (rr *ArtifactHubResourceResult) ResourceVersion() (string, error) {
+	//TODO
+	return "", nil
+}
+
+// MinPipelinesVersion returns the minimum pipeline version the resource is compatible
+func (rr *TektonHubResourceResult) MinPipelinesVersion() (string, error) {
+	if err := rr.UnmarshalData(); err != nil {
+		return "", err
+	}
+
+	if rr.version != "" {
+		return *rr.resourceWithVersionData.MinPipelinesVersion, nil
+	}
+	return *rr.resourceData.LatestVersion.MinPipelinesVersion, nil
+}
+
+// MinPipelinesVersion returns the minimum pipeline version the resource is compatible
+func (rr *ArtifactHubResourceResult) MinPipelinesVersion() (string, error) {
+	//TODO
+	return "", nil
 }

--- a/api/pkg/cli/hub/get_resource_version.go
+++ b/api/pkg/cli/hub/get_resource_version.go
@@ -28,8 +28,13 @@ type resVersionsResponse = rclient.VersionsByIDResponseBody
 // ResVersions is the data in API response consisting of list of versions
 type ResVersions = rclient.VersionsResponseBody
 
+type ResourceVersionResult interface {
+	ResourceVersions() (*ResVersions, error)
+	UnmarshalData() error
+}
+
 // ResourceVersionResult defines API response
-type ResourceVersionResult struct {
+type TektonHubResourceVersionResult struct {
 	rr       ResourceResult
 	data     []byte
 	status   int
@@ -41,29 +46,29 @@ type ResourceVersionResult struct {
 // GetResourceVersion queries the data using Artifact Hub Endpoint
 func (a *artifactHubClient) GetResourceVersions(opt ResourceOption) ResourceVersionResult {
 	// Todo: implement GetResourceVersions for Artifact Hub
-	return ResourceVersionResult{}
+	return nil
 }
 
 // GetResourceVersion queries the data using Tekton Hub Endpoint
 func (t *tektonHubclient) GetResourceVersions(opt ResourceOption) ResourceVersionResult {
 
-	rvr := ResourceVersionResult{set: false}
+	rvr := TektonHubResourceVersionResult{set: false}
 
-	rvr.rr = t.GetResource(opt)
-	if rvr.err = rvr.rr.unmarshalData(); rvr.err != nil {
-		return rvr
+	rr := t.GetResource(opt).(*TektonHubResourceResult)
+	rvr.rr = rr
+	if rvr.err = rvr.rr.UnmarshalData(); rvr.err != nil {
+		return &rvr
 	}
 
 	var resID uint
-	if rvr.rr.version != "" {
-		resID = *rvr.rr.resourceWithVersionData.Resource.ID
+	if rr.version != "" {
+		resID = *rr.resourceWithVersionData.Resource.ID
 	} else {
-		resID = *rvr.rr.resourceData.ID
+		resID = *rr.resourceData.ID
 	}
-
 	rvr.data, rvr.status, rvr.err = t.Get(resVersionsEndpoint(resID))
 
-	return rvr
+	return &rvr
 }
 
 // Endpoint computes the endpoint url using input provided
@@ -71,7 +76,7 @@ func resVersionsEndpoint(rID uint) string {
 	return fmt.Sprintf("/v1/resource/%s/versions", strconv.FormatUint(uint64(rID), 10))
 }
 
-func (rvr *ResourceVersionResult) unmarshalData() error {
+func (rvr *TektonHubResourceVersionResult) UnmarshalData() error {
 	if rvr.err != nil {
 		return rvr.err
 	}
@@ -89,9 +94,9 @@ func (rvr *ResourceVersionResult) unmarshalData() error {
 }
 
 // ResourceVersions returns list of all versions of the resource
-func (rvr *ResourceVersionResult) ResourceVersions() (*ResVersions, error) {
+func (rvr *TektonHubResourceVersionResult) ResourceVersions() (*ResVersions, error) {
 
-	if err := rvr.unmarshalData(); err != nil {
+	if err := rvr.UnmarshalData(); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Part of https://github.com/tektoncd/hub/issues/691. No functionality change in this PR. Prior to this change, the Hub CLI supports only 1 type of Hub (Tekton Hub).

This commit 
1) refactors the `ResourceResult` and `ResourceVersionResult` to interfaces; 
2) creates THResourceResult and THResourceVersionResult structs implementing the interfaces, keeping original support for Tekton Hub; 
3) creates AHResourceResult and AHResourceVersionResult for Artifact Hub, implementations will be added in later PRs.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Run API Unit Tests, Lint Checks, API Design, Golden Files with `make api-check`
- [ ] Run UI Unit Tests, Lint Checks with `make ui-check`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._
