### PR TITLE
 [TEP-0079] Add Support Tier in tkn hub install command

### DIFF
--- a/api/pkg/cli/app/app.go
+++ b/api/pkg/cli/app/app.go
@@ -58,7 +58,7 @@ func (c *cli) Hub() hub.Client {
 
 func (c *cli) SetHub(hubType string) error {
 	if hubType == hub.TektonHubType {
-		c.hub = hub.NewTektonHubClient()
+		c.hub = hub.NewtektonHubClient()
 		return nil
 	} else if hubType == hub.ArtifactHubType {
 		c.hub = hub.NewArtifactHubClient()

--- a/api/pkg/cli/cmd/check_upgrade/check_upgrade_test.go
+++ b/api/pkg/cli/cmd/check_upgrade/check_upgrade_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/tektoncd/hub/api/pkg/cli/hub"
 	"github.com/tektoncd/hub/api/pkg/cli/test"
 	cb "github.com/tektoncd/hub/api/pkg/cli/test/builder"
 	res "github.com/tektoncd/hub/api/v1/gen/resource"
@@ -65,7 +66,7 @@ var resVersion = &res.ResourceData{
 }
 
 func TestUpdateAvailable(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -114,7 +115,7 @@ func TestUpdateAvailable(t *testing.T) {
 }
 
 func TestUpdateAvailable_WithSkippedTasks(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -173,7 +174,7 @@ func TestUpdateAvailable_WithSkippedTasks(t *testing.T) {
 }
 
 func TestNoUpdateAvailable(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -222,7 +223,7 @@ func TestNoUpdateAvailable(t *testing.T) {
 }
 
 func TestNoUpdateAvailable_TaskNotInstalledViaHubCLI(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -270,7 +271,7 @@ func TestNoUpdateAvailable_TaskNotInstalledViaHubCLI(t *testing.T) {
 }
 
 func TestUpdateAvailable_PipelinesUnknown(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -313,7 +314,7 @@ func TestUpdateAvailable_PipelinesUnknown(t *testing.T) {
 }
 
 func TestUpdateAvailable_WithSkippedTasks_PipelinesUnknown(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 

--- a/api/pkg/cli/cmd/downgrade/downgrade_test.go
+++ b/api/pkg/cli/cmd/downgrade/downgrade_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/tektoncd/hub/api/pkg/cli/hub"
 	"github.com/tektoncd/hub/api/pkg/cli/test"
 	cb "github.com/tektoncd/hub/api/pkg/cli/test/builder"
 	res "github.com/tektoncd/hub/api/v1/gen/resource"
@@ -111,7 +112,7 @@ var taskWitholdVersionYaml = &res.ResourceContent{
 }
 
 func TestDowngrade_ResourceNotExist(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	version := "v1beta1"
 	dynamic := test.DynamicClient()
@@ -132,7 +133,7 @@ func TestDowngrade_ResourceNotExist(t *testing.T) {
 }
 
 func TestDowngrade_VersionCatalogMissing(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	existingTask := &v1beta1.Task{
 		ObjectMeta: metav1.ObjectMeta{
@@ -160,7 +161,7 @@ func TestDowngrade_VersionCatalogMissing(t *testing.T) {
 }
 
 func TestDowngrade_VersionMissing(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	existingTask := &v1beta1.Task{
 		ObjectMeta: metav1.ObjectMeta{
@@ -189,7 +190,7 @@ func TestDowngrade_VersionMissing(t *testing.T) {
 }
 
 func TestDowngrade(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -256,7 +257,7 @@ func TestDowngrade(t *testing.T) {
 }
 
 func TestDowngrade_ToSpecificVersion(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -324,7 +325,7 @@ func TestDowngrade_ToSpecificVersion(t *testing.T) {
 }
 
 func TestDowngrade_SameVersionError(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -389,7 +390,7 @@ func TestDowngrade_SameVersionError(t *testing.T) {
 }
 
 func TestDowngrade_HigherVersionError(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -439,7 +440,7 @@ func TestDowngrade_HigherVersionError(t *testing.T) {
 }
 
 func TestDowngrade_ToSpecificVersionRespectingPipelinesVersionSuccess(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -511,7 +512,7 @@ func TestDowngrade_ToSpecificVersionRespectingPipelinesVersionSuccess(t *testing
 }
 
 func TestDowngrade_ToSpecificVersionRespectingPipelinesVersionFailure(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 

--- a/api/pkg/cli/cmd/get/get_test.go
+++ b/api/pkg/cli/cmd/get/get_test.go
@@ -113,7 +113,7 @@ func TestValidate_ErrorCase(t *testing.T) {
 }
 
 func TestGetResource_WithNewVersion(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -145,7 +145,7 @@ func TestGetResource_WithNewVersion(t *testing.T) {
 }
 
 func TestGetResource_WithOldVersion(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -176,7 +176,7 @@ func TestGetResource_WithOldVersion(t *testing.T) {
 }
 
 func TestGet_ResourceNotFound(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 

--- a/api/pkg/cli/cmd/get/task_test.go
+++ b/api/pkg/cli/cmd/get/task_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/tektoncd/hub/api/pkg/cli/hub"
 	"github.com/tektoncd/hub/api/pkg/cli/test"
 	res "github.com/tektoncd/hub/api/v1/gen/resource"
 	"gopkg.in/h2non/gock.v1"
@@ -63,7 +64,7 @@ var taskWithOldVersionYaml = &res.ResourceContent{
 }
 
 func TestGetTask_WithNewVersion(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -96,7 +97,7 @@ func TestGetTask_WithNewVersion(t *testing.T) {
 }
 
 func TestGetTask_AsClusterTask(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 

--- a/api/pkg/cli/cmd/info/info_test.go
+++ b/api/pkg/cli/cmd/info/info_test.go
@@ -20,8 +20,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	res "github.com/tektoncd/hub/api/v1/gen/resource"
+	"github.com/tektoncd/hub/api/pkg/cli/hub"
 	"github.com/tektoncd/hub/api/pkg/cli/test"
+	res "github.com/tektoncd/hub/api/v1/gen/resource"
 	"gopkg.in/h2non/gock.v1"
 	"gotest.tools/v3/golden"
 )
@@ -140,7 +141,7 @@ func mockApi(io InfoOptions, taskWithVersion *res.ResourceVersionData) {
 }
 
 func TestInfoTask_WithLatestVersion(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -170,7 +171,7 @@ func TestInfoTask_WithLatestVersion(t *testing.T) {
 }
 
 func TestInfoTask_WithOldVersion(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -200,7 +201,7 @@ func TestInfoTask_WithOldVersion(t *testing.T) {
 }
 
 func TestPipelineTask_MultiLineDescription(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 

--- a/api/pkg/cli/cmd/install/install.go
+++ b/api/pkg/cli/cmd/install/install.go
@@ -157,8 +157,14 @@ func (opts *options) run() error {
 
 	resourceInstaller := installer.New(opts.cs)
 
+	org, err := opts.hubRes.Org()
+	if err != nil {
+		return err
+	}
+	hubType := opts.cli.Hub().GetType()
+
 	var errors []error
-	opts.resource, errors = resourceInstaller.Install([]byte(manifest), opts.from, opts.cs.Namespace())
+	opts.resource, errors = resourceInstaller.Install([]byte(manifest), hubType, org, opts.from, opts.cs.Namespace())
 
 	if len(errors) != 0 {
 		resourcePipelineMinVersion, err := opts.hubRes.MinPipelinesVersion()

--- a/api/pkg/cli/cmd/install/install_test.go
+++ b/api/pkg/cli/cmd/install/install_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/tektoncd/hub/api/pkg/cli/hub"
 	"github.com/tektoncd/hub/api/pkg/cli/test"
 	cb "github.com/tektoncd/hub/api/pkg/cli/test/builder"
 	res "github.com/tektoncd/hub/api/v1/gen/resource"
@@ -100,89 +101,129 @@ var taskWithOldVersionYaml = &res.ResourceContent{
 }
 
 func TestInstall_NewResource(t *testing.T) {
-	cli := test.NewCLI()
+	t.Run("TestInstall_NewResource_TektonHub", func(t *testing.T) {
+		defer gock.Off()
 
-	defer gock.Off()
+		rVer := &res.ResourceVersionYaml{Data: taskWithNewVersionYaml}
+		resWithVersion := res.NewViewedResourceVersionYaml(rVer, "default")
+		resInfo := fmt.Sprintf("%s/%s/%s/%s", "tekton", "task", "foo", "0.3")
+		gock.New(test.API).
+			Get("/resource/" + resInfo + "/yaml").
+			Reply(200).
+			JSON(&resWithVersion.Projected)
 
-	rVer := &res.ResourceVersionYaml{Data: taskWithNewVersionYaml}
-	resWithVersion := res.NewViewedResourceVersionYaml(rVer, "default")
+		resVersion := &res.ResourceVersion{Data: resVersion}
+		resource := res.NewViewedResourceVersion(resVersion, "default")
+		gock.New(test.API).
+			Get("/resource/tekton/task/foo/0.3").
+			Reply(200).
+			JSON(&resource.Projected)
 
-	resInfo := fmt.Sprintf("%s/%s/%s/%s", "tekton", "task", "foo", "0.3")
+		buf := new(bytes.Buffer)
+		from := "tekton"
+		version := "0.3"
+		opts := prepareOpts(t, buf, hub.TektonHubType, from, version)
 
-	gock.New(test.API).
-		Get("/resource/" + resInfo + "/yaml").
-		Reply(200).
-		JSON(&resWithVersion.Projected)
+		err := opts.run()
+		assert.NoError(t, err)
+		assert.Equal(t, "WARN: tekton pipelines version unknown, this resource is compatible with pipelines min version v0.12\nTask foo(0.3) installed in hub namespace\n", buf.String())
+		assert.Equal(t, gock.IsDone(), true)
+	})
 
-	resVersion := &res.ResourceVersion{Data: resVersion}
-	resource := res.NewViewedResourceVersion(resVersion, "default")
-	gock.New(test.API).
-		Get("/resource/tekton/task/foo/0.3").
-		Reply(200).
-		JSON(&resource.Projected)
+	t.Run("TestInstall_NewResource_ArtifactHub", func(t *testing.T) {
+		defer gock.Off()
 
-	buf := new(bytes.Buffer)
-	cli.SetStream(buf, buf)
+		from := "tekton-catalog-tasks"
+		task := "foo"
+		version := "0.3.0"
+		ahPkgData := hub.ArtifactHubPkgData{
+			ManifestRaw:    task1,
+			PipelineMinVer: "0.12",
+		}
+		ahPkg := hub.ArtifactHubPkgResponse{Data: ahPkgData}
+		resInfo := fmt.Sprintf("%s-%s/%s/%s/%s", "/api/v1/packages/tekton", "task", from, task, version)
 
-	version := "v1beta1"
-	dynamic := test.DynamicClient()
+		gock.New(test.API).
+			Get(resInfo).
+			Reply(200).
+			JSON(&ahPkg)
 
-	cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{})
-	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"task"})
+		buf := new(bytes.Buffer)
+		opts := prepareOpts(t, buf, hub.ArtifactHubType, from, version)
 
-	opts := &options{
-		cs:      test.FakeClientSet(cs.Pipeline, dynamic, "hub"),
-		cli:     cli,
-		kind:    "task",
-		args:    []string{"foo"},
-		from:    "tekton",
-		version: "0.3",
-	}
+		err := opts.run()
 
-	err := opts.run()
-	assert.NoError(t, err)
-	assert.Equal(t, "WARN: tekton pipelines version unknown, this resource is compatible with pipelines min version v0.12\nTask foo(0.3) installed in hub namespace\n", buf.String())
-	assert.Equal(t, gock.IsDone(), true)
+		assert.NoError(t, err)
+		assert.Equal(t, "WARN: tekton pipelines version unknown, this resource is compatible with pipelines min version v0.12\nTask foo(0.3) installed in hub namespace\n", buf.String())
+		assert.Equal(t, gock.IsDone(), true)
+	})
 }
 
-func TestInstall_ResourceNotFoundInHub(t *testing.T) {
-	cli := test.NewCLI()
-
-	defer gock.Off()
-
-	gock.New(test.API).
-		Get("/resource/tekton/task/foo/0.3/yaml").
-		Reply(404).
-		JSON(&goa.ServiceError{
-			ID:      "123456",
-			Name:    "not-found",
-			Message: "resource not found",
-		})
-
-	gock.New(test.API).
-		Get("/resource/tekton/task/foo/0.3").
-		Reply(404).
-		JSON(&goa.ServiceError{
-			ID:      "123456",
-			Name:    "not-found",
-			Message: "resource not found",
-		})
-
-	opts := &options{
-		cli:     cli,
-		kind:    "task",
-		args:    []string{"foo"},
-		from:    "tekton",
-		version: "0.3",
+func TestInstall_ResourceNotFound(t *testing.T) {
+	serviceErr := &goa.ServiceError{
+		ID:      "123456",
+		Name:    "not-found",
+		Message: "resource not found",
 	}
 
-	err := opts.run()
-	assert.Error(t, err)
-	assert.EqualError(t, err, "Task foo(0.3) from tekton catalog not found in Hub")
+	t.Run("TestInstall_ResourceNotFound_TektonHub", func(t *testing.T) {
+		cli := test.NewCLI(hub.TektonHubType)
+
+		defer gock.Off()
+
+		gock.New(test.API).
+			Get("/resource/tekton/task/foo/0.3/yaml").
+			Reply(404).
+			JSON(serviceErr)
+		gock.New(test.API).
+			Get("/resource/tekton/task/foo/0.3").
+			Reply(404).
+			JSON(serviceErr)
+
+		opts := &options{
+			cli:     cli,
+			kind:    "task",
+			args:    []string{"foo"},
+			from:    "tekton",
+			version: "0.3",
+		}
+
+		err := opts.run()
+		assert.Error(t, err)
+		assert.EqualError(t, err, "Task foo(0.3) from tekton catalog not found in Hub")
+	})
+
+	t.Run("TestInstall_ResourceNotFound_ArtifactHub", func(t *testing.T) {
+		cli := test.NewCLI(hub.ArtifactHubType)
+
+		defer gock.Off()
+
+		from := "tekton-catalog-tasks-not-exist"
+		task := "foo"
+		version := "0.3.0"
+		resInfo := fmt.Sprintf("%s-%s/%s/%s/%s", "/api/v1/packages/tekton", "task", from, task, version)
+
+		gock.New(test.API).
+			Get(resInfo).
+			Reply(404).
+			JSON(serviceErr)
+
+		opts := &options{
+			cli:     cli,
+			kind:    "task",
+			args:    []string{"foo"},
+			from:    from,
+			version: version,
+		}
+
+		err := opts.run()
+		assert.Error(t, err)
+		assert.EqualError(t, err, "Task foo(0.3.0) from tekton-catalog-tasks-not-exist catalog not found in Hub")
+	})
 }
 
 func TestInstall_ResourceAlreadyExistError(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -235,7 +276,7 @@ func TestInstall_ResourceAlreadyExistError(t *testing.T) {
 }
 
 func TestInstall_UpgradeError(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -284,12 +325,12 @@ func TestInstall_UpgradeError(t *testing.T) {
 
 	err := opts.run()
 	assert.Error(t, err)
-	assert.EqualError(t, err, "Task foo(0.1) already exists in hub namespace. Use upgrade command to install v0.3")
+	assert.EqualError(t, err, "Task foo(0.1.0) already exists in hub namespace. Use upgrade command to install v0.3.0")
 	assert.Equal(t, gock.IsDone(), true)
 }
 
 func TestInstall_SameVersionError(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -338,12 +379,12 @@ func TestInstall_SameVersionError(t *testing.T) {
 
 	err := opts.run()
 	assert.Error(t, err)
-	assert.EqualError(t, err, "Task foo(0.3) already exists in hub namespace. Use reinstall command to overwrite existing")
+	assert.EqualError(t, err, "Task foo(0.3.0) already exists in hub namespace. Use reinstall command to overwrite existing")
 	assert.Equal(t, gock.IsDone(), true)
 }
 
 func TestInstall_LowerVersionError(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -391,12 +432,12 @@ func TestInstall_LowerVersionError(t *testing.T) {
 
 	err := opts.run()
 	assert.Error(t, err)
-	assert.EqualError(t, err, "Task foo(0.7) already exists in hub namespace. Use downgrade command to install v0.3")
+	assert.EqualError(t, err, "Task foo(0.7.0) already exists in hub namespace. Use downgrade command to install v0.3.0")
 	assert.Equal(t, gock.IsDone(), true)
 }
 
 func TestInstall_RespectingPipelinesVersion(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -447,7 +488,7 @@ func TestInstall_RespectingPipelinesVersion(t *testing.T) {
 }
 
 func TestInstall_RespectingPipelinesVersionFailure(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -498,7 +539,7 @@ func TestInstall_RespectingPipelinesVersionFailure(t *testing.T) {
 }
 
 func TestInstall_DeprecatedVersion(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -542,4 +583,22 @@ func TestInstall_DeprecatedVersion(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "WARN: tekton pipelines version unknown, this resource is compatible with pipelines min version v0.12\nWARN: This version has been deprecated\nTask foo(0.2) installed in hub namespace\n", buf.String())
 	assert.Equal(t, gock.IsDone(), true)
+}
+
+func prepareOpts(t *testing.T, buf *bytes.Buffer, hubType, from, version string) *options {
+	cli := test.NewCLI(hubType)
+	cli.SetStream(buf, buf)
+
+	dynamic := test.DynamicClient()
+	cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{})
+	cs.Pipeline.Resources = cb.APIResourceList("v1beta1", []string{"task"})
+
+	return &options{
+		cs:      test.FakeClientSet(cs.Pipeline, dynamic, "hub"),
+		cli:     cli,
+		kind:    "task",
+		args:    []string{"foo"},
+		from:    from,
+		version: version,
+	}
 }

--- a/api/pkg/cli/cmd/reinstall/reinstall_test.go
+++ b/api/pkg/cli/cmd/reinstall/reinstall_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/tektoncd/hub/api/pkg/cli/hub"
 	"github.com/tektoncd/hub/api/pkg/cli/test"
 	cb "github.com/tektoncd/hub/api/pkg/cli/test/builder"
 	res "github.com/tektoncd/hub/api/v1/gen/resource"
@@ -78,7 +79,7 @@ var taskWithNewVersionYaml = &res.ResourceContent{
 }
 
 func TestReinstall_ResourceNotExist(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	version := "v1beta1"
 	dynamic := test.DynamicClient()
@@ -99,7 +100,7 @@ func TestReinstall_ResourceNotExist(t *testing.T) {
 }
 
 func TestReinstall_VersionCatalogMissing(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	existingTask := &v1beta1.Task{
 		ObjectMeta: metav1.ObjectMeta{
@@ -127,7 +128,7 @@ func TestReinstall_VersionCatalogMissing(t *testing.T) {
 }
 
 func TestReinstall_VersionMissing(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	existingTask := &v1beta1.Task{
 		ObjectMeta: metav1.ObjectMeta{
@@ -156,7 +157,7 @@ func TestReinstall_VersionMissing(t *testing.T) {
 }
 
 func TestReinstall_DifferentVersionPassedByFlag(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -210,7 +211,7 @@ func TestReinstall_DifferentVersionPassedByFlag(t *testing.T) {
 }
 
 func TestReinstall_DifferentCatalogPassedByFlag(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -267,7 +268,7 @@ func TestReinstall_DifferentCatalogPassedByFlag(t *testing.T) {
 }
 
 func TestReinstall(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -321,7 +322,7 @@ func TestReinstall(t *testing.T) {
 }
 
 func TestReinstall_RespectPipelinesVersionSuccess(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -379,7 +380,7 @@ func TestReinstall_RespectPipelinesVersionSuccess(t *testing.T) {
 }
 
 func TestReinstall_RespectPipelinesVersionFailure(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 

--- a/api/pkg/cli/cmd/search/search_test.go
+++ b/api/pkg/cli/cmd/search/search_test.go
@@ -164,7 +164,7 @@ func TestValidate_ErrorCases(t *testing.T) {
 }
 
 func TestSearch_TableFormat(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 	rArr := &res.Resources{Data: res.ResourceDataCollection{res1, res2}}
@@ -193,7 +193,7 @@ func TestSearch_TableFormat(t *testing.T) {
 
 // Updates golden file as GOA is unable to pick the min view of catalog
 func TestSearch_JSONFormat(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 	rArr := &res.Resources{Data: res.ResourceDataCollection{res2}}
@@ -221,7 +221,7 @@ func TestSearch_JSONFormat(t *testing.T) {
 }
 
 func TestSearch_ResourceNotFound(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -250,7 +250,7 @@ func TestSearch_ResourceNotFound(t *testing.T) {
 }
 
 func TestSearch_InternalServerError(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -280,7 +280,7 @@ func TestSearch_InternalServerError(t *testing.T) {
 }
 
 func TestSearch_InvalidAPIServerURL(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	err := cli.Hub().SetURL("api")
 	assert.Error(t, err)

--- a/api/pkg/cli/cmd/upgrade/upgrade_test.go
+++ b/api/pkg/cli/cmd/upgrade/upgrade_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/tektoncd/hub/api/pkg/cli/hub"
 	"github.com/tektoncd/hub/api/pkg/cli/test"
 	cb "github.com/tektoncd/hub/api/pkg/cli/test/builder"
 	res "github.com/tektoncd/hub/api/v1/gen/resource"
@@ -78,7 +79,7 @@ var taskWithNewVersionYaml = &res.ResourceContent{
 }
 
 func TestUpgrade_ResourceNotExist(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	version := "v1beta1"
 	dynamic := test.DynamicClient()
@@ -99,7 +100,7 @@ func TestUpgrade_ResourceNotExist(t *testing.T) {
 }
 
 func TestUpgrade_VersionCatalogMissing(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	existingTask := &v1beta1.Task{
 		ObjectMeta: metav1.ObjectMeta{
@@ -127,7 +128,7 @@ func TestUpgrade_VersionCatalogMissing(t *testing.T) {
 }
 
 func TestUpgrade_VersionMissing(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	existingTask := &v1beta1.Task{
 		ObjectMeta: metav1.ObjectMeta{
@@ -156,7 +157,7 @@ func TestUpgrade_VersionMissing(t *testing.T) {
 }
 
 func TestUpgrade_ToSpecificVersion(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -211,7 +212,7 @@ func TestUpgrade_ToSpecificVersion(t *testing.T) {
 }
 
 func TestUpgrade_SameVersionError(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -263,7 +264,7 @@ func TestUpgrade_SameVersionError(t *testing.T) {
 }
 
 func TestUpgrade_LowerVersionError(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -315,7 +316,7 @@ func TestUpgrade_LowerVersionError(t *testing.T) {
 }
 
 func TestUpgrade_ToSpecificVersion_RespectingPipelineSuccess(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 
@@ -375,7 +376,7 @@ func TestUpgrade_ToSpecificVersion_RespectingPipelineSuccess(t *testing.T) {
 }
 
 func TestUpgrade_ToSpecificVersion_RespectingPipelineFailure(t *testing.T) {
-	cli := test.NewCLI()
+	cli := test.NewCLI(hub.TektonHubType)
 
 	defer gock.Off()
 

--- a/api/pkg/cli/hub/get_catalog.go
+++ b/api/pkg/cli/hub/get_catalog.go
@@ -34,7 +34,7 @@ type ArtifactHubCatalogResponse struct {
 	Name string `json:"name,omitempty"`
 }
 
-func (c *tektonHubclient) GetAllCatalogs() CatalogResult {
+func (c *tektonHubClient) GetAllCatalogs() CatalogResult {
 	data, status, err := c.Get(tektonHubCatEndpoint)
 	if status == http.StatusNotFound {
 		err = nil
@@ -76,7 +76,7 @@ func (a *artifactHubClient) GetCatalogsList() ([]string, error) {
 	return cat, nil
 }
 
-func (t *tektonHubclient) GetCatalogsList() ([]string, error) {
+func (t *tektonHubClient) GetCatalogsList() ([]string, error) {
 	// Get all catalogs
 	c := t.GetAllCatalogs()
 

--- a/api/pkg/cli/hub/get_catalog.go
+++ b/api/pkg/cli/hub/get_catalog.go
@@ -22,13 +22,6 @@ import (
 	cclient "github.com/tektoncd/hub/api/v1/gen/http/catalog/client"
 )
 
-const (
-	tektonHubCatEndpoint    = "/v1/catalogs"
-	artifactHubCatEndpoint  = "/api/v1/repositories/search"
-	artifactHubTaskType     = 7
-	artifactHubPipelineType = 11
-)
-
 type CatalogResult struct {
 	data    []byte
 	status  int
@@ -37,7 +30,7 @@ type CatalogResult struct {
 }
 type CatalogData = cclient.ListResponseBody
 
-type artifactHubCatalogResponse struct {
+type ArtifactHubCatalogResponse struct {
 	Name string `json:"name,omitempty"`
 }
 
@@ -64,12 +57,12 @@ func (cr *CatalogResult) Type() (CatalogData, error) {
 }
 
 func (a *artifactHubClient) GetCatalogsList() ([]string, error) {
-	data, _, err := a.Get(fmt.Sprintf("%s?kind=%v&kind=%v", artifactHubCatEndpoint, artifactHubTaskType, artifactHubPipelineType))
+	data, _, err := a.Get(fmt.Sprintf("%s?kind=%v&kind=%v", artifactHubCatSearchEndpoint, artifactHubTaskType, artifactHubPipelineType))
 	if err != nil {
 		return nil, err
 	}
 
-	resp := []artifactHubCatalogResponse{}
+	resp := []ArtifactHubCatalogResponse{}
 	err = json.Unmarshal(data, &resp)
 	if err != nil {
 		return nil, fmt.Errorf("error unmarshalling json response: %w", err)

--- a/api/pkg/cli/hub/get_resource_version.go
+++ b/api/pkg/cli/hub/get_resource_version.go
@@ -50,7 +50,7 @@ func (a *artifactHubClient) GetResourceVersions(opt ResourceOption) ResourceVers
 }
 
 // GetResourceVersions queries the data using Tekton Hub Endpoint
-func (t *tektonHubclient) GetResourceVersions(opt ResourceOption) ResourceVersionResult {
+func (t *tektonHubClient) GetResourceVersions(opt ResourceOption) ResourceVersionResult {
 
 	rvr := THResourceVersionResult{set: false}
 

--- a/api/pkg/cli/hub/get_resource_version.go
+++ b/api/pkg/cli/hub/get_resource_version.go
@@ -28,12 +28,12 @@ type resVersionsResponse = rclient.VersionsByIDResponseBody
 // ResVersions is the data in API response consisting of list of versions
 type ResVersions = rclient.VersionsResponseBody
 
+// ResourceVersionResult defines API response
 type ResourceVersionResult interface {
 	ResourceVersions() (*ResVersions, error)
 	UnmarshalData() error
 }
 
-// ResourceVersionResult defines API response
 type THResourceVersionResult struct {
 	rr       ResourceResult
 	data     []byte
@@ -43,13 +43,13 @@ type THResourceVersionResult struct {
 	versions *ResVersions
 }
 
-// GetResourceVersion queries the data using Artifact Hub Endpoint
+// GetResourceVersions queries the data using Artifact Hub Endpoint
 func (a *artifactHubClient) GetResourceVersions(opt ResourceOption) ResourceVersionResult {
 	// Todo: implement GetResourceVersions for Artifact Hub
 	return nil
 }
 
-// GetResourceVersion queries the data using Tekton Hub Endpoint
+// GetResourceVersions queries the data using Tekton Hub Endpoint
 func (t *tektonHubclient) GetResourceVersions(opt ResourceOption) ResourceVersionResult {
 
 	rvr := THResourceVersionResult{set: false}

--- a/api/pkg/cli/hub/hub.go
+++ b/api/pkg/cli/hub/hub.go
@@ -54,7 +54,7 @@ type Client interface {
 	GetResourceVersionslist(opt ResourceOption) ([]string, error)
 }
 
-type tektonHubclient struct {
+type tektonHubClient struct {
 	apiURL string
 }
 
@@ -62,11 +62,11 @@ type artifactHubClient struct {
 	apiURL string
 }
 
-var _ Client = (*tektonHubclient)(nil)
+var _ Client = (*tektonHubClient)(nil)
 var _ Client = (*artifactHubClient)(nil)
 
-func NewTektonHubClient() *tektonHubclient {
-	return &tektonHubclient{apiURL: tektonHubURL}
+func NewtektonHubClient() *tektonHubClient {
+	return &tektonHubClient{apiURL: tektonHubURL}
 }
 
 func NewArtifactHubClient() *artifactHubClient {
@@ -84,7 +84,7 @@ func (a *artifactHubClient) GetType() string {
 }
 
 // GetType returns the type of the Hub Client
-func (t *tektonHubclient) GetType() string {
+func (t *tektonHubClient) GetType() string {
 	return TektonHubType
 }
 
@@ -104,7 +104,7 @@ func (a *artifactHubClient) SetURL(apiURL string) error {
 // SetURL validates and sets the Tekton Hub apiURL server URL
 // URL passed through flag will take precedence over the Tekton Hub API URL
 // in config file and default URL
-func (t *tektonHubclient) SetURL(apiURL string) error {
+func (t *tektonHubClient) SetURL(apiURL string) error {
 	resUrl, err := resolveUrl(apiURL, "TEKTON_HUB_API_SERVER", tektonHubURL)
 	if err != nil {
 		return err
@@ -120,7 +120,7 @@ func (a *artifactHubClient) Get(endpoint string) ([]byte, int, error) {
 }
 
 // Get gets data from Tekton Hub
-func (t *tektonHubclient) Get(endpoint string) ([]byte, int, error) {
+func (t *tektonHubClient) Get(endpoint string) ([]byte, int, error) {
 	return get(t.apiURL + endpoint)
 }
 

--- a/api/pkg/cli/hub/hub.go
+++ b/api/pkg/cli/hub/hub.go
@@ -33,6 +33,12 @@ const (
 	tektonHubURL   = "https://api.hub.tekton.dev"
 	artifactHubURL = "https://artifacthub.io"
 	hubConfigPath  = ".tekton/hub-config"
+
+	tektonHubCatEndpoint         = "/v1/catalogs"
+	artifactHubCatSearchEndpoint = "/api/v1/repositories/search"
+	artifactHubCatInfoEndpoint   = "/api/v1/packages/tekton"
+	artifactHubTaskType          = 7
+	artifactHubPipelineType      = 11
 )
 
 type Client interface {

--- a/api/pkg/cli/hub/hub_test.go
+++ b/api/pkg/cli/hub/hub_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestSetURL_TektonHub(t *testing.T) {
-	tHub := &tektonHubclient{}
+	tHub := &tektonHubClient{}
 	err := tHub.SetURL("http://localhost:80000")
 	assert.NoError(t, err)
 
@@ -42,7 +42,7 @@ func TestSetURL_ArtifactHub(t *testing.T) {
 
 func TestSetURL_InvalidCase(t *testing.T) {
 
-	hub := &tektonHubclient{}
+	hub := &tektonHubClient{}
 	err := hub.SetURL("abc")
 	assert.Error(t, err)
 	assert.EqualError(t, err, "parse \"abc\": invalid URI for request")

--- a/api/pkg/cli/hub/search.go
+++ b/api/pkg/cli/hub/search.go
@@ -65,7 +65,7 @@ func (t *tektonHubclient) Search(so SearchOption) SearchResult {
 }
 
 // Search queries the data using Hub Endpoint
-func (h *artifactHubCatalogResponse) Search(so SearchOption) SearchResult {
+func (h *ArtifactHubCatalogResponse) Search(so SearchOption) SearchResult {
 	// todo: implement Search function for Artifact Hub
 	return SearchResult{}
 }

--- a/api/pkg/cli/hub/search.go
+++ b/api/pkg/cli/hub/search.go
@@ -56,7 +56,7 @@ func (a *artifactHubClient) Search(so SearchOption) SearchResult {
 }
 
 // Search queries the data using TektonHub Endpoint
-func (t *tektonHubclient) Search(so SearchOption) SearchResult {
+func (t *tektonHubClient) Search(so SearchOption) SearchResult {
 	data, status, err := t.Get(so.Endpoint())
 	if status == http.StatusNotFound {
 		err = nil

--- a/api/pkg/cli/installer/action.go
+++ b/api/pkg/cli/installer/action.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/tektoncd/hub/api/pkg/cli/hub"
 	tknVer "github.com/tektoncd/hub/api/pkg/cli/version"
 	kErr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,8 +28,14 @@ import (
 )
 
 const (
-	catalogLabel = "hub.tekton.dev/catalog"
-	versionLabel = "app.kubernetes.io/version"
+	versionLabel            = "app.kubernetes.io/version"
+	tektonHubCatalogLabel   = "hub.tekton.dev/catalog"
+	artifactHubCatalogLabel = "artifacthub.io/catalog"
+	artifactHubOrgLabel     = "artifacthub.io/org"
+	supportTierLabel        = "artifacthub.io/support-tier"
+	communitySupportTier    = "Community"
+	verifiedSupportTier     = "Verified"
+	verifiedCatOrg          = "tektoncd"
 )
 
 // Errors
@@ -82,7 +89,7 @@ func (i *Installer) checkVersion(resPipMinVersion string) error {
 }
 
 // Install a resource
-func (i *Installer) Install(data []byte, catalog, namespace string) (*unstructured.Unstructured, []error) {
+func (i *Installer) Install(data []byte, hubType, org, catalog, namespace string) (*unstructured.Unstructured, []error) {
 
 	errors := make([]error, 0)
 
@@ -110,7 +117,7 @@ func (i *Installer) Install(data []byte, catalog, namespace string) (*unstructur
 	if err != nil {
 		// If error is notFoundError then create the resource
 		if kErr.IsNotFound(err) {
-			resp, err := i.createRes(newRes, catalog, namespace)
+			resp, err := i.createRes(newRes, hubType, org, catalog, namespace)
 			if err != nil {
 				errors = append(errors, err)
 			}
@@ -259,7 +266,7 @@ func checkLabels(res *unstructured.Unstructured) error {
 	}
 
 	_, versionOk := labels[versionLabel]
-	_, catalogOk := labels[catalogLabel]
+	_, catalogOk := labels[tektonHubCatalogLabel]
 
 	// If both label exist then return nil
 	if versionOk == catalogOk && versionOk {
@@ -277,9 +284,12 @@ func checkLabels(res *unstructured.Unstructured) error {
 	return nil
 }
 
-func (i *Installer) createRes(obj *unstructured.Unstructured, catalog, namespace string) (*unstructured.Unstructured, error) {
+func (i *Installer) createRes(obj *unstructured.Unstructured, hubType, org, catalog, namespace string) (*unstructured.Unstructured, error) {
 
-	addCatalogLabel(obj, catalog)
+	if err := addCatalogLabel(obj, hubType, org, catalog); err != nil {
+		return nil, err
+	}
+
 	res, err := i.create(obj, namespace, metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
@@ -288,8 +298,11 @@ func (i *Installer) createRes(obj *unstructured.Unstructured, catalog, namespace
 }
 
 func (i *Installer) updateRes(existing, new *unstructured.Unstructured, catalog, namespace string) (*unstructured.Unstructured, error) {
+	// TODO: update addCatalogLabel() params when supporting upgrade/downgrade command for artifact type
+	if err := addCatalogLabel(new, hub.TektonHubType, "", catalog); err != nil {
+		return nil, err
+	}
 
-	addCatalogLabel(new, catalog)
 	// replace label, annotation and spec of old resource with new
 	existing.SetLabels(new.GetLabels())
 	existing.SetAnnotations(new.GetAnnotations())
@@ -314,11 +327,27 @@ func toUnstructured(data []byte) (*unstructured.Unstructured, error) {
 	return res, nil
 }
 
-func addCatalogLabel(obj *unstructured.Unstructured, catalog string) {
+func addCatalogLabel(obj *unstructured.Unstructured, hubType, org, catalog string) error {
 	labels := obj.GetLabels()
 	if len(labels) == 0 {
 		labels = make(map[string]string)
 	}
-	labels[catalogLabel] = catalog
+
+	switch hubType {
+	case hub.TektonHubType:
+		labels[tektonHubCatalogLabel] = catalog
+	case hub.ArtifactHubType:
+		labels[artifactHubCatalogLabel] = catalog
+		if org == verifiedCatOrg {
+			labels[supportTierLabel] = verifiedSupportTier
+		} else {
+			labels[supportTierLabel] = communitySupportTier
+		}
+		labels[artifactHubOrgLabel] = org
+	default:
+		return fmt.Errorf("hub type: %s not supported in addCatalogLabel", hubType)
+	}
+
 	obj.SetLabels(labels)
+	return nil
 }

--- a/api/pkg/cli/installer/action_test.go
+++ b/api/pkg/cli/installer/action_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/tektoncd/hub/api/pkg/cli/hub"
 	"github.com/tektoncd/hub/api/pkg/cli/test"
 	cb "github.com/tektoncd/hub/api/pkg/cli/test/builder"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -43,12 +44,64 @@ spec:
 `
 
 func TestToUnstructuredAndAddLabel(t *testing.T) {
-	obj, err := toUnstructured([]byte(res))
-	assert.NoError(t, err)
-	assert.Equal(t, "foo", obj.GetName())
+	testCases := []struct {
+		name            string
+		data            string
+		hubType         string
+		org             string
+		catalog         string
+		wantSupportTier string
+		wantCatalog     string
+		wantOrg         string
+	}{
+		{
+			name:        "Install From Tekton Hub",
+			data:        res,
+			hubType:     hub.TektonHubType,
+			org:         "",
+			catalog:     "tekton",
+			wantCatalog: "tekton",
+		},
+		{
+			name:            "Install Verified Catalog From Artifact Hub",
+			data:            res,
+			hubType:         hub.ArtifactHubType,
+			org:             verifiedCatOrg,
+			catalog:         "golang-build",
+			wantSupportTier: verifiedSupportTier,
+			wantCatalog:     "golang-build",
+			wantOrg:         "tektoncd",
+		},
+		{
+			name:            "Install Community Catalog From Artifact Hub",
+			data:            res,
+			hubType:         hub.ArtifactHubType,
+			org:             "tekton-legacy",
+			catalog:         "tekton-catalog-tasks",
+			wantSupportTier: communitySupportTier,
+			wantCatalog:     "tekton-catalog-tasks",
+			wantOrg:         "tekton-legacy",
+		},
+	}
 
-	addCatalogLabel(obj, "tekton")
-	assert.Equal(t, "tekton", obj.GetLabels()[catalogLabel])
+	for _, tc := range testCases {
+		obj, err := toUnstructured([]byte(res))
+		assert.NoError(t, err)
+		assert.Equal(t, "foo", obj.GetName())
+
+		if err := addCatalogLabel(obj, tc.hubType, tc.org, tc.catalog); err != nil {
+			t.Errorf("%s", err.Error())
+		}
+
+		if tc.hubType == hub.ArtifactHubType {
+			assert.Equal(t, tc.wantSupportTier, obj.GetLabels()[supportTierLabel])
+			assert.Equal(t, tc.wantCatalog, obj.GetLabels()[artifactHubCatalogLabel])
+			assert.Equal(t, tc.wantOrg, obj.GetLabels()[artifactHubOrgLabel])
+			assert.Equal(t, "", obj.GetLabels()[tektonHubCatalogLabel])
+		} else {
+			assert.Equal(t, "tekton", obj.GetLabels()[tektonHubCatalogLabel])
+		}
+	}
 }
 
 func TestListInstalled(t *testing.T) {

--- a/api/pkg/cli/test/config.go
+++ b/api/pkg/cli/test/config.go
@@ -36,12 +36,12 @@ func NewCLI(hubType string) *cli {
 	var h hub.Client
 	switch hubType {
 	case hub.TektonHubType:
-		h = hub.NewTektonHubClient()
+		h = hub.NewtektonHubClient()
 	case hub.ArtifactHubType:
 		h = hub.NewArtifactHubClient()
 	default:
 		fmt.Printf("invalid hub type: %s, using default type: %s to continue", hubType, hub.TektonHubType)
-		h = hub.NewTektonHubClient()
+		h = hub.NewtektonHubClient()
 	}
 
 	if err := h.SetURL(API); err != nil {
@@ -68,7 +68,7 @@ func (c *cli) Hub() hub.Client {
 
 func (c *cli) SetHub(hubType string) error {
 	if hubType == hub.TektonHubType {
-		c.hub = hub.NewTektonHubClient()
+		c.hub = hub.NewtektonHubClient()
 		return nil
 	} else if hubType == hub.ArtifactHubType {
 		c.hub = hub.NewArtifactHubClient()

--- a/api/pkg/cli/test/config.go
+++ b/api/pkg/cli/test/config.go
@@ -32,8 +32,18 @@ type cli struct {
 
 var _ app.CLI = (*cli)(nil)
 
-func NewCLI() *cli {
-	h := hub.NewTektonHubClient()
+func NewCLI(hubType string) *cli {
+	var h hub.Client
+	switch hubType {
+	case hub.TektonHubType:
+		h = hub.NewTektonHubClient()
+	case hub.ArtifactHubType:
+		h = hub.NewArtifactHubClient()
+	default:
+		fmt.Printf("invalid hub type: %s, using default type: %s to continue", hubType, hub.TektonHubType)
+		h = hub.NewTektonHubClient()
+	}
+
 	if err := h.SetURL(API); err != nil {
 		fmt.Printf("Failed validate and set the hub apiURL server URL %v", err)
 	}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Part of https://github.com/tektoncd/hub/issues/691 and based on https://github.com/tektoncd/hub/pull/757. Prior to this change, no support tier, catalog or org information was added to the resource annotation when installing from Hub.

This commit adds `artifacthub.io/catalog`, "artifacthub.io/org" and "artifacthub.io/support-tier" labels to the resource being installed to indicate the source and support tier of the catalog. The 3 labels will only be added when installing with `--type artifact` flag.

Details can be found in https://github.com/tektoncd/community/blob/main/teps/0079-tekton-catalog-support-tiers.md#cli

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Run API Unit Tests, Lint Checks, API Design, Golden Files with `make api-check`
- [ ] Run UI Unit Tests, Lint Checks with `make ui-check`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._
