### PR TITLE
[TEP-0079] Add Support Tier in tkn hub install command

### DIFF
--- a/api/pkg/cli/cmd/install/install.go
+++ b/api/pkg/cli/cmd/install/install.go
@@ -171,8 +171,14 @@ func (opts *options) run() error {
 
 	resourceInstaller := installer.New(opts.cs)
 
+	org, err := opts.hubRes.Org()
+	if err != nil {
+		return err
+	}
+	hubType := opts.cli.Hub().GetType()
+
 	var errors []error
-	opts.resource, errors = resourceInstaller.Install([]byte(manifest), opts.from, opts.cs.Namespace())
+	opts.resource, errors = resourceInstaller.Install([]byte(manifest), hubType, org, opts.from, opts.cs.Namespace())
 
 	if len(errors) != 0 {
 		resourcePipelineMinVersion, err := opts.hubRes.MinPipelinesVersion()

--- a/api/pkg/cli/hub/get_catalog.go
+++ b/api/pkg/cli/hub/get_catalog.go
@@ -34,7 +34,7 @@ type artifactHubCatalogResponse struct {
 	Name string `json:"name,omitempty"`
 }
 
-func (c *tektonHubclient) GetAllCatalogs() CatalogResult {
+func (c *tektonHubClient) GetAllCatalogs() CatalogResult {
 	data, status, err := c.Get(tektonHubCatEndpoint)
 	if status == http.StatusNotFound {
 		err = nil
@@ -76,7 +76,7 @@ func (a *artifactHubClient) GetCatalogsList() ([]string, error) {
 	return cat, nil
 }
 
-func (t *tektonHubclient) GetCatalogsList() ([]string, error) {
+func (t *tektonHubClient) GetCatalogsList() ([]string, error) {
 	// Get all catalogs
 	c := t.GetAllCatalogs()
 

--- a/api/pkg/cli/hub/get_resource_version.go
+++ b/api/pkg/cli/hub/get_resource_version.go
@@ -50,7 +50,7 @@ func (a *artifactHubClient) GetResourceVersions(opt ResourceOption) ResourceVers
 }
 
 // GetResourceVersions queries the data using Tekton Hub Endpoint
-func (t *tektonHubclient) GetResourceVersions(opt ResourceOption) ResourceVersionResult {
+func (t *tektonHubClient) GetResourceVersions(opt ResourceOption) ResourceVersionResult {
 
 	rvr := TektonHubResourceVersionResult{set: false}
 

--- a/api/pkg/cli/hub/hub.go
+++ b/api/pkg/cli/hub/hub.go
@@ -54,7 +54,7 @@ type Client interface {
 	GetResourceVersionslist(opt ResourceOption) ([]string, error)
 }
 
-type tektonHubclient struct {
+type tektonHubClient struct {
 	apiURL string
 }
 
@@ -62,11 +62,11 @@ type artifactHubClient struct {
 	apiURL string
 }
 
-var _ Client = (*tektonHubclient)(nil)
+var _ Client = (*tektonHubClient)(nil)
 var _ Client = (*artifactHubClient)(nil)
 
-func NewTektonHubClient() *tektonHubclient {
-	return &tektonHubclient{apiURL: tektonHubURL}
+func NewTektonHubClient() *tektonHubClient {
+	return &tektonHubClient{apiURL: tektonHubURL}
 }
 
 func NewArtifactHubClient() *artifactHubClient {
@@ -84,7 +84,7 @@ func (a *artifactHubClient) GetType() string {
 }
 
 // GetType returns the type of the Hub Client
-func (t *tektonHubclient) GetType() string {
+func (t *tektonHubClient) GetType() string {
 	return TektonHubType
 }
 
@@ -104,7 +104,7 @@ func (a *artifactHubClient) SetURL(apiURL string) error {
 // SetURL validates and sets the Tekton Hub apiURL server URL
 // URL passed through flag will take precedence over the Tekton Hub API URL
 // in config file and default URL
-func (t *tektonHubclient) SetURL(apiURL string) error {
+func (t *tektonHubClient) SetURL(apiURL string) error {
 	resUrl, err := resolveUrl(apiURL, "TEKTON_HUB_API_SERVER", tektonHubURL)
 	if err != nil {
 		return err
@@ -120,7 +120,7 @@ func (a *artifactHubClient) Get(endpoint string) ([]byte, int, error) {
 }
 
 // Get gets data from Tekton Hub
-func (t *tektonHubclient) Get(endpoint string) ([]byte, int, error) {
+func (t *tektonHubClient) Get(endpoint string) ([]byte, int, error) {
 	return get(t.apiURL + endpoint)
 }
 

--- a/api/pkg/cli/hub/hub_test.go
+++ b/api/pkg/cli/hub/hub_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestSetURL_TektonHub(t *testing.T) {
-	tHub := &tektonHubclient{}
+	tHub := &tektonHubClient{}
 	err := tHub.SetURL("http://localhost:80000")
 	assert.NoError(t, err)
 
@@ -42,7 +42,7 @@ func TestSetURL_ArtifactHub(t *testing.T) {
 
 func TestSetURL_InvalidCase(t *testing.T) {
 
-	hub := &tektonHubclient{}
+	hub := &tektonHubClient{}
 	err := hub.SetURL("abc")
 	assert.Error(t, err)
 	assert.EqualError(t, err, "parse \"abc\": invalid URI for request")

--- a/api/pkg/cli/hub/search.go
+++ b/api/pkg/cli/hub/search.go
@@ -56,7 +56,7 @@ func (a *artifactHubClient) Search(so SearchOption) SearchResult {
 }
 
 // Search queries the data using TektonHub Endpoint
-func (t *tektonHubclient) Search(so SearchOption) SearchResult {
+func (t *tektonHubClient) Search(so SearchOption) SearchResult {
 	data, status, err := t.Get(so.Endpoint())
 	if status == http.StatusNotFound {
 		err = nil


### PR DESCRIPTION
Part of #691. Prior to this change, no support tier, catalog or org information was added to the resource annotation when installing from Artifact Hub.

This commit adds `artifacthub.io/catalog`, `artifacthub.io/org` and `artifacthub.io/support-tier` labels to the resource being installed to indicate the source and support tier of the catalog. The 3 labels will only be added when installing with `--type artifact` flag.

Details can be found in https://github.com/tektoncd/community/blob/main/teps/0079-tekton-catalog-support-tiers.md#cli

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Run API Unit Tests, Lint Checks, API Design, Golden Files with `make api-check`
- [ ] Run UI Unit Tests, Lint Checks with `make ui-check`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._
