### PR TITLE
Fix build test failure for api and lint errors

### DIFF
--- a/.github/workflows/goa-gen-dependabot.yml
+++ b/.github/workflows/goa-gen-dependabot.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v2
       with:
-        go-version: 1.18.x
+        go-version: 1.19.x
     - uses: actions/checkout@v2
     - name: Goa bump
       run: |

--- a/api/gen/admin/client.go
+++ b/api/gen/admin/client.go
@@ -29,11 +29,11 @@ func NewClient(updateAgent, refreshConfig goa.Endpoint) *Client {
 
 // UpdateAgent calls the "UpdateAgent" endpoint of the "admin" service.
 // UpdateAgent may return the following errors:
-//	- "invalid-payload" (type *goa.ServiceError): Invalid request body
-//	- "invalid-token" (type *goa.ServiceError): Invalid User token
-//	- "invalid-scopes" (type *goa.ServiceError): Invalid Token scopes
-//	- "internal-error" (type *goa.ServiceError): Internal server error
-//	- error: internal error
+//   - "invalid-payload" (type *goa.ServiceError): Invalid request body
+//   - "invalid-token" (type *goa.ServiceError): Invalid User token
+//   - "invalid-scopes" (type *goa.ServiceError): Invalid Token scopes
+//   - "internal-error" (type *goa.ServiceError): Internal server error
+//   - error: internal error
 func (c *Client) UpdateAgent(ctx context.Context, p *UpdateAgentPayload) (res *UpdateAgentResult, err error) {
 	var ires interface{}
 	ires, err = c.UpdateAgentEndpoint(ctx, p)
@@ -45,11 +45,11 @@ func (c *Client) UpdateAgent(ctx context.Context, p *UpdateAgentPayload) (res *U
 
 // RefreshConfig calls the "RefreshConfig" endpoint of the "admin" service.
 // RefreshConfig may return the following errors:
-//	- "invalid-payload" (type *goa.ServiceError): Invalid request body
-//	- "invalid-token" (type *goa.ServiceError): Invalid User token
-//	- "invalid-scopes" (type *goa.ServiceError): Invalid Token scopes
-//	- "internal-error" (type *goa.ServiceError): Internal server error
-//	- error: internal error
+//   - "invalid-payload" (type *goa.ServiceError): Invalid request body
+//   - "invalid-token" (type *goa.ServiceError): Invalid User token
+//   - "invalid-scopes" (type *goa.ServiceError): Invalid Token scopes
+//   - "internal-error" (type *goa.ServiceError): Internal server error
+//   - error: internal error
 func (c *Client) RefreshConfig(ctx context.Context, p *RefreshConfigPayload) (res *RefreshConfigResult, err error) {
 	var ires interface{}
 	ires, err = c.RefreshConfigEndpoint(ctx, p)

--- a/api/gen/catalog/client.go
+++ b/api/gen/catalog/client.go
@@ -31,9 +31,9 @@ func NewClient(refresh, refreshAll, catalogError goa.Endpoint) *Client {
 
 // Refresh calls the "Refresh" endpoint of the "catalog" service.
 // Refresh may return the following errors:
-//	- "internal-error" (type *goa.ServiceError): Internal Server Error
-//	- "not-found" (type *goa.ServiceError): Resource Not Found Error
-//	- error: internal error
+//   - "internal-error" (type *goa.ServiceError): Internal Server Error
+//   - "not-found" (type *goa.ServiceError): Resource Not Found Error
+//   - error: internal error
 func (c *Client) Refresh(ctx context.Context, p *RefreshPayload) (res *Job, err error) {
 	var ires interface{}
 	ires, err = c.RefreshEndpoint(ctx, p)
@@ -45,9 +45,9 @@ func (c *Client) Refresh(ctx context.Context, p *RefreshPayload) (res *Job, err 
 
 // RefreshAll calls the "RefreshAll" endpoint of the "catalog" service.
 // RefreshAll may return the following errors:
-//	- "internal-error" (type *goa.ServiceError): Internal Server Error
-//	- "not-found" (type *goa.ServiceError): Resource Not Found Error
-//	- error: internal error
+//   - "internal-error" (type *goa.ServiceError): Internal Server Error
+//   - "not-found" (type *goa.ServiceError): Resource Not Found Error
+//   - error: internal error
 func (c *Client) RefreshAll(ctx context.Context, p *RefreshAllPayload) (res []*Job, err error) {
 	var ires interface{}
 	ires, err = c.RefreshAllEndpoint(ctx, p)
@@ -59,9 +59,9 @@ func (c *Client) RefreshAll(ctx context.Context, p *RefreshAllPayload) (res []*J
 
 // CatalogError calls the "CatalogError" endpoint of the "catalog" service.
 // CatalogError may return the following errors:
-//	- "internal-error" (type *goa.ServiceError): Internal Server Error
-//	- "not-found" (type *goa.ServiceError): Resource Not Found Error
-//	- error: internal error
+//   - "internal-error" (type *goa.ServiceError): Internal Server Error
+//   - "not-found" (type *goa.ServiceError): Resource Not Found Error
+//   - error: internal error
 func (c *Client) CatalogError(ctx context.Context, p *CatalogErrorPayload) (res *CatalogErrorResult, err error) {
 	var ires interface{}
 	ires, err = c.CatalogErrorEndpoint(ctx, p)

--- a/api/gen/category/client.go
+++ b/api/gen/category/client.go
@@ -27,8 +27,8 @@ func NewClient(list goa.Endpoint) *Client {
 
 // List calls the "list" endpoint of the "category" service.
 // List may return the following errors:
-//	- "internal-error" (type *goa.ServiceError): Internal Server Error
-//	- error: internal error
+//   - "internal-error" (type *goa.ServiceError): Internal Server Error
+//   - error: internal error
 func (c *Client) List(ctx context.Context) (res *ListResult, err error) {
 	var ires interface{}
 	ires, err = c.ListEndpoint(ctx, nil)

--- a/api/gen/http/admin/client/encode_decode.go
+++ b/api/gen/http/admin/client/encode_decode.go
@@ -62,11 +62,11 @@ func EncodeUpdateAgentRequest(encoder func(*http.Request) goahttp.Encoder) func(
 // admin UpdateAgent endpoint. restoreBody controls whether the response body
 // should be restored after having been read.
 // DecodeUpdateAgentResponse may return the following errors:
-//	- "invalid-payload" (type *goa.ServiceError): http.StatusBadRequest
-//	- "invalid-token" (type *goa.ServiceError): http.StatusUnauthorized
-//	- "invalid-scopes" (type *goa.ServiceError): http.StatusForbidden
-//	- "internal-error" (type *goa.ServiceError): http.StatusInternalServerError
-//	- error: internal error
+//   - "invalid-payload" (type *goa.ServiceError): http.StatusBadRequest
+//   - "invalid-token" (type *goa.ServiceError): http.StatusUnauthorized
+//   - "invalid-scopes" (type *goa.ServiceError): http.StatusForbidden
+//   - "internal-error" (type *goa.ServiceError): http.StatusInternalServerError
+//   - error: internal error
 func DecodeUpdateAgentResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
 	return func(resp *http.Response) (interface{}, error) {
 		if restoreBody {
@@ -199,10 +199,10 @@ func EncodeRefreshConfigRequest(encoder func(*http.Request) goahttp.Encoder) fun
 // admin RefreshConfig endpoint. restoreBody controls whether the response body
 // should be restored after having been read.
 // DecodeRefreshConfigResponse may return the following errors:
-//	- "invalid-token" (type *goa.ServiceError): http.StatusUnauthorized
-//	- "invalid-scopes" (type *goa.ServiceError): http.StatusForbidden
-//	- "internal-error" (type *goa.ServiceError): http.StatusInternalServerError
-//	- error: internal error
+//   - "invalid-token" (type *goa.ServiceError): http.StatusUnauthorized
+//   - "invalid-scopes" (type *goa.ServiceError): http.StatusForbidden
+//   - "internal-error" (type *goa.ServiceError): http.StatusInternalServerError
+//   - error: internal error
 func DecodeRefreshConfigResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
 	return func(resp *http.Response) (interface{}, error) {
 		if restoreBody {

--- a/api/gen/http/catalog/client/encode_decode.go
+++ b/api/gen/http/catalog/client/encode_decode.go
@@ -70,9 +70,9 @@ func EncodeRefreshRequest(encoder func(*http.Request) goahttp.Encoder) func(*htt
 // catalog Refresh endpoint. restoreBody controls whether the response body
 // should be restored after having been read.
 // DecodeRefreshResponse may return the following errors:
-//	- "not-found" (type *goa.ServiceError): http.StatusNotFound
-//	- "internal-error" (type *goa.ServiceError): http.StatusInternalServerError
-//	- error: internal error
+//   - "not-found" (type *goa.ServiceError): http.StatusNotFound
+//   - "internal-error" (type *goa.ServiceError): http.StatusInternalServerError
+//   - error: internal error
 func DecodeRefreshResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
 	return func(resp *http.Response) (interface{}, error) {
 		if restoreBody {
@@ -179,8 +179,8 @@ func EncodeRefreshAllRequest(encoder func(*http.Request) goahttp.Encoder) func(*
 // catalog RefreshAll endpoint. restoreBody controls whether the response body
 // should be restored after having been read.
 // DecodeRefreshAllResponse may return the following errors:
-//	- "internal-error" (type *goa.ServiceError): http.StatusInternalServerError
-//	- error: internal error
+//   - "internal-error" (type *goa.ServiceError): http.StatusInternalServerError
+//   - error: internal error
 func DecodeRefreshAllResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
 	return func(resp *http.Response) (interface{}, error) {
 		if restoreBody {
@@ -287,8 +287,8 @@ func EncodeCatalogErrorRequest(encoder func(*http.Request) goahttp.Encoder) func
 // catalog CatalogError endpoint. restoreBody controls whether the response
 // body should be restored after having been read.
 // DecodeCatalogErrorResponse may return the following errors:
-//	- "internal-error" (type *goa.ServiceError): http.StatusInternalServerError
-//	- error: internal error
+//   - "internal-error" (type *goa.ServiceError): http.StatusInternalServerError
+//   - error: internal error
 func DecodeCatalogErrorResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
 	return func(resp *http.Response) (interface{}, error) {
 		if restoreBody {

--- a/api/gen/http/category/client/encode_decode.go
+++ b/api/gen/http/category/client/encode_decode.go
@@ -37,8 +37,8 @@ func (c *Client) BuildListRequest(ctx context.Context, v interface{}) (*http.Req
 // list endpoint. restoreBody controls whether the response body should be
 // restored after having been read.
 // DecodeListResponse may return the following errors:
-//	- "internal-error" (type *goa.ServiceError): http.StatusInternalServerError
-//	- error: internal error
+//   - "internal-error" (type *goa.ServiceError): http.StatusInternalServerError
+//   - error: internal error
 func DecodeListResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
 	return func(resp *http.Response) (interface{}, error) {
 		if restoreBody {

--- a/api/gen/http/cli/hub/cli.go
+++ b/api/gen/http/cli/hub/cli.go
@@ -25,8 +25,7 @@ import (
 
 // UsageCommands returns the set of commands and sub-commands using the format
 //
-//    command (subcommand1|subcommand2|...)
-//
+//	command (subcommand1|subcommand2|...)
 func UsageCommands() string {
 	return `admin (update-agent|refresh-config)
 catalog (refresh|refresh-all|catalog-error)

--- a/api/gen/http/rating/client/encode_decode.go
+++ b/api/gen/http/rating/client/encode_decode.go
@@ -68,11 +68,11 @@ func EncodeGetRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Re
 // endpoint. restoreBody controls whether the response body should be restored
 // after having been read.
 // DecodeGetResponse may return the following errors:
-//	- "not-found" (type *goa.ServiceError): http.StatusNotFound
-//	- "internal-error" (type *goa.ServiceError): http.StatusInternalServerError
-//	- "invalid-token" (type *goa.ServiceError): http.StatusUnauthorized
-//	- "invalid-scopes" (type *goa.ServiceError): http.StatusForbidden
-//	- error: internal error
+//   - "not-found" (type *goa.ServiceError): http.StatusNotFound
+//   - "internal-error" (type *goa.ServiceError): http.StatusInternalServerError
+//   - "invalid-token" (type *goa.ServiceError): http.StatusUnauthorized
+//   - "invalid-scopes" (type *goa.ServiceError): http.StatusForbidden
+//   - error: internal error
 func DecodeGetResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
 	return func(resp *http.Response) (interface{}, error) {
 		if restoreBody {
@@ -219,11 +219,11 @@ func EncodeUpdateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http
 // Update endpoint. restoreBody controls whether the response body should be
 // restored after having been read.
 // DecodeUpdateResponse may return the following errors:
-//	- "not-found" (type *goa.ServiceError): http.StatusNotFound
-//	- "internal-error" (type *goa.ServiceError): http.StatusInternalServerError
-//	- "invalid-token" (type *goa.ServiceError): http.StatusUnauthorized
-//	- "invalid-scopes" (type *goa.ServiceError): http.StatusForbidden
-//	- error: internal error
+//   - "not-found" (type *goa.ServiceError): http.StatusNotFound
+//   - "internal-error" (type *goa.ServiceError): http.StatusInternalServerError
+//   - "invalid-token" (type *goa.ServiceError): http.StatusUnauthorized
+//   - "invalid-scopes" (type *goa.ServiceError): http.StatusForbidden
+//   - error: internal error
 func DecodeUpdateResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
 	return func(resp *http.Response) (interface{}, error) {
 		if restoreBody {

--- a/api/gen/rating/client.go
+++ b/api/gen/rating/client.go
@@ -29,11 +29,11 @@ func NewClient(get, update goa.Endpoint) *Client {
 
 // Get calls the "Get" endpoint of the "rating" service.
 // Get may return the following errors:
-//	- "not-found" (type *goa.ServiceError): Resource Not Found Error
-//	- "internal-error" (type *goa.ServiceError): Internal server error
-//	- "invalid-token" (type *goa.ServiceError): Invalid User token
-//	- "invalid-scopes" (type *goa.ServiceError): Invalid User scope
-//	- error: internal error
+//   - "not-found" (type *goa.ServiceError): Resource Not Found Error
+//   - "internal-error" (type *goa.ServiceError): Internal server error
+//   - "invalid-token" (type *goa.ServiceError): Invalid User token
+//   - "invalid-scopes" (type *goa.ServiceError): Invalid User scope
+//   - error: internal error
 func (c *Client) Get(ctx context.Context, p *GetPayload) (res *GetResult, err error) {
 	var ires interface{}
 	ires, err = c.GetEndpoint(ctx, p)
@@ -45,11 +45,11 @@ func (c *Client) Get(ctx context.Context, p *GetPayload) (res *GetResult, err er
 
 // Update calls the "Update" endpoint of the "rating" service.
 // Update may return the following errors:
-//	- "not-found" (type *goa.ServiceError): Resource Not Found Error
-//	- "internal-error" (type *goa.ServiceError): Internal server error
-//	- "invalid-token" (type *goa.ServiceError): Invalid User token
-//	- "invalid-scopes" (type *goa.ServiceError): Invalid User scope
-//	- error: internal error
+//   - "not-found" (type *goa.ServiceError): Resource Not Found Error
+//   - "internal-error" (type *goa.ServiceError): Internal server error
+//   - "invalid-token" (type *goa.ServiceError): Invalid User token
+//   - "invalid-scopes" (type *goa.ServiceError): Invalid User scope
+//   - error: internal error
 func (c *Client) Update(ctx context.Context, p *UpdatePayload) (err error) {
 	_, err = c.UpdateEndpoint(ctx, p)
 	return

--- a/api/gen/resource/client.go
+++ b/api/gen/resource/client.go
@@ -39,9 +39,9 @@ func NewClient(query, list, versionsByID, byCatalogKindNameVersion, byVersionID,
 
 // Query calls the "Query" endpoint of the "resource" service.
 // Query may return the following errors:
-//	- "internal-error" (type *goa.ServiceError): Internal Server Error
-//	- "not-found" (type *goa.ServiceError): Resource Not Found Error
-//	- error: internal error
+//   - "internal-error" (type *goa.ServiceError): Internal Server Error
+//   - "not-found" (type *goa.ServiceError): Resource Not Found Error
+//   - error: internal error
 func (c *Client) Query(ctx context.Context, p *QueryPayload) (res *QueryResult, err error) {
 	var ires interface{}
 	ires, err = c.QueryEndpoint(ctx, p)
@@ -53,9 +53,9 @@ func (c *Client) Query(ctx context.Context, p *QueryPayload) (res *QueryResult, 
 
 // List calls the "List" endpoint of the "resource" service.
 // List may return the following errors:
-//	- "internal-error" (type *goa.ServiceError): Internal Server Error
-//	- "not-found" (type *goa.ServiceError): Resource Not Found Error
-//	- error: internal error
+//   - "internal-error" (type *goa.ServiceError): Internal Server Error
+//   - "not-found" (type *goa.ServiceError): Resource Not Found Error
+//   - error: internal error
 func (c *Client) List(ctx context.Context) (res *Resources, err error) {
 	var ires interface{}
 	ires, err = c.ListEndpoint(ctx, nil)
@@ -67,9 +67,9 @@ func (c *Client) List(ctx context.Context) (res *Resources, err error) {
 
 // VersionsByID calls the "VersionsByID" endpoint of the "resource" service.
 // VersionsByID may return the following errors:
-//	- "internal-error" (type *goa.ServiceError): Internal Server Error
-//	- "not-found" (type *goa.ServiceError): Resource Not Found Error
-//	- error: internal error
+//   - "internal-error" (type *goa.ServiceError): Internal Server Error
+//   - "not-found" (type *goa.ServiceError): Resource Not Found Error
+//   - error: internal error
 func (c *Client) VersionsByID(ctx context.Context, p *VersionsByIDPayload) (res *VersionsByIDResult, err error) {
 	var ires interface{}
 	ires, err = c.VersionsByIDEndpoint(ctx, p)
@@ -82,9 +82,9 @@ func (c *Client) VersionsByID(ctx context.Context, p *VersionsByIDPayload) (res 
 // ByCatalogKindNameVersion calls the "ByCatalogKindNameVersion" endpoint of
 // the "resource" service.
 // ByCatalogKindNameVersion may return the following errors:
-//	- "internal-error" (type *goa.ServiceError): Internal Server Error
-//	- "not-found" (type *goa.ServiceError): Resource Not Found Error
-//	- error: internal error
+//   - "internal-error" (type *goa.ServiceError): Internal Server Error
+//   - "not-found" (type *goa.ServiceError): Resource Not Found Error
+//   - error: internal error
 func (c *Client) ByCatalogKindNameVersion(ctx context.Context, p *ByCatalogKindNameVersionPayload) (res *ByCatalogKindNameVersionResult, err error) {
 	var ires interface{}
 	ires, err = c.ByCatalogKindNameVersionEndpoint(ctx, p)
@@ -96,9 +96,9 @@ func (c *Client) ByCatalogKindNameVersion(ctx context.Context, p *ByCatalogKindN
 
 // ByVersionID calls the "ByVersionId" endpoint of the "resource" service.
 // ByVersionID may return the following errors:
-//	- "internal-error" (type *goa.ServiceError): Internal Server Error
-//	- "not-found" (type *goa.ServiceError): Resource Not Found Error
-//	- error: internal error
+//   - "internal-error" (type *goa.ServiceError): Internal Server Error
+//   - "not-found" (type *goa.ServiceError): Resource Not Found Error
+//   - error: internal error
 func (c *Client) ByVersionID(ctx context.Context, p *ByVersionIDPayload) (res *ByVersionIDResult, err error) {
 	var ires interface{}
 	ires, err = c.ByVersionIDEndpoint(ctx, p)
@@ -111,9 +111,9 @@ func (c *Client) ByVersionID(ctx context.Context, p *ByVersionIDPayload) (res *B
 // ByCatalogKindName calls the "ByCatalogKindName" endpoint of the "resource"
 // service.
 // ByCatalogKindName may return the following errors:
-//	- "internal-error" (type *goa.ServiceError): Internal Server Error
-//	- "not-found" (type *goa.ServiceError): Resource Not Found Error
-//	- error: internal error
+//   - "internal-error" (type *goa.ServiceError): Internal Server Error
+//   - "not-found" (type *goa.ServiceError): Resource Not Found Error
+//   - error: internal error
 func (c *Client) ByCatalogKindName(ctx context.Context, p *ByCatalogKindNamePayload) (res *ByCatalogKindNameResult, err error) {
 	var ires interface{}
 	ires, err = c.ByCatalogKindNameEndpoint(ctx, p)
@@ -125,9 +125,9 @@ func (c *Client) ByCatalogKindName(ctx context.Context, p *ByCatalogKindNamePayl
 
 // ByID calls the "ById" endpoint of the "resource" service.
 // ByID may return the following errors:
-//	- "internal-error" (type *goa.ServiceError): Internal Server Error
-//	- "not-found" (type *goa.ServiceError): Resource Not Found Error
-//	- error: internal error
+//   - "internal-error" (type *goa.ServiceError): Internal Server Error
+//   - "not-found" (type *goa.ServiceError): Resource Not Found Error
+//   - error: internal error
 func (c *Client) ByID(ctx context.Context, p *ByIDPayload) (res *ByIDResult, err error) {
 	var ires interface{}
 	ires, err = c.ByIDEndpoint(ctx, p)

--- a/api/pkg/app/data.go
+++ b/api/pkg/app/data.go
@@ -16,8 +16,9 @@ package app
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"os"
 	"strings"
 )
 
@@ -75,13 +76,12 @@ func httpRead(url string) ([]byte, error) {
 		return nil, fmt.Errorf(resp.Status)
 	}
 
-	return ioutil.ReadAll(resp.Body)
+	return io.ReadAll(resp.Body)
 }
 
 // readLocalFile reads data from a local file using file path
 func readLocalFile(path string) ([]byte, error) {
-
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/api/pkg/cli/hub/hub.go
+++ b/api/pkg/cli/hub/hub.go
@@ -16,7 +16,7 @@ package hub
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os/user"
@@ -184,7 +184,7 @@ func httpGet(url string) ([]byte, int, error) {
 	}
 	defer resp.Body.Close()
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/api/pkg/service/admin/admin_http_test.go
+++ b/api/pkg/service/admin/admin_http_test.go
@@ -18,8 +18,9 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"os"
 	"testing"
 
 	"github.com/golang-jwt/jwt"
@@ -62,7 +63,7 @@ func TestUpdateAgent_Http_NewAgent(t *testing.T) {
 		WithHeader("Authorization", accessToken).WithBody(data).
 		Check().
 		HasStatus(200).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -97,7 +98,7 @@ func TestUpdateAgent_Http_NormalUserExistWithName(t *testing.T) {
 		WithHeader("Authorization", accessToken).WithBody(data).
 		Check().
 		HasStatus(400).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -127,7 +128,7 @@ func TestUpdateAgent_Http_InvalidScopeCase(t *testing.T) {
 		WithHeader("Authorization", accessToken).WithBody(data).
 		Check().
 		HasStatus(400).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -159,7 +160,7 @@ func TestUpdateAgent_Http_UpdateCase(t *testing.T) {
 		WithHeader("Authorization", accessToken).WithBody(data).
 		Check().
 		HasStatus(200).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -205,7 +206,7 @@ func TestRefreshConfig_Http(t *testing.T) {
 	RefreshConfigChecker(tc).Test(t, http.MethodPost, "/system/config/refresh").
 		WithHeader("Authorization", token).Check().
 		HasStatus(200).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -230,7 +231,7 @@ func TestRefreshConfig_Http(t *testing.T) {
 }
 
 func computeChecksum() (string, error) {
-	data, err := ioutil.ReadFile("../../../test/config/config.yaml")
+	data, err := os.ReadFile("../../../test/config/config.yaml")
 	if err != nil {
 		return "", err
 	}

--- a/api/pkg/service/catalog/catalog_http_test.go
+++ b/api/pkg/service/catalog/catalog_http_test.go
@@ -17,7 +17,7 @@ package catalog
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -51,7 +51,7 @@ func TestRefresh_Http(t *testing.T) {
 	RefreshChecker(tc).Test(t, http.MethodPost, "/catalog/catalog-official/refresh").
 		WithHeader("Authorization", token).Check().
 		HasStatus(200).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -93,7 +93,7 @@ func TestRefreshAll_Http(t *testing.T) {
 	RefreshAllChecker(tc).Test(t, http.MethodPost, "/catalog/refresh").
 		WithHeader("Authorization", token).Check().
 		HasStatus(200).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -117,7 +117,7 @@ func TestCatalogError_Http(t *testing.T) {
 	CatalogErrorChecker(tc).Test(t, http.MethodGet, "/catalog/catalog-official/error").
 		WithHeader("Authorization", token).Check().
 		HasStatus(200).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -141,7 +141,7 @@ func TestCatalogError_HttpHavingNoError(t *testing.T) {
 	CatalogErrorChecker(tc).Test(t, http.MethodGet, "/catalog/catalog-community/error").
 		WithHeader("Authorization", token).Check().
 		HasStatus(200).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 

--- a/api/pkg/service/category/category_http_test.go
+++ b/api/pkg/service/category/category_http_test.go
@@ -16,7 +16,7 @@ package category
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -40,7 +40,7 @@ func TestCategories_List_Http(t *testing.T) {
 
 	checker.Test(t, http.MethodGet, "/categories").Check().
 		HasStatus(http.StatusOK).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -63,7 +63,7 @@ func TestCategories_List_Http_V1(t *testing.T) {
 
 	checker.Test(t, http.MethodGet, "/v1/categories").Check().
 		HasStatus(http.StatusOK).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 

--- a/api/pkg/service/rating/rating_http_test.go
+++ b/api/pkg/service/rating/rating_http_test.go
@@ -16,7 +16,7 @@ package rating
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -47,7 +47,7 @@ func TestGet_Http_InvalidToken(t *testing.T) {
 	GetChecker(tc).Test(t, http.MethodGet, "/resource/1/rating").
 		WithHeader("Authorization", "invalidToken").Check().
 		HasStatus(401).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -75,7 +75,7 @@ func TestGet_Http_ExpiredToken(t *testing.T) {
 	GetChecker(tc).Test(t, http.MethodGet, "/resource/1/rating").
 		WithHeader("Authorization", accessToken).Check().
 		HasStatus(401).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -102,7 +102,7 @@ func TestGet_Http_InvalidScopes(t *testing.T) {
 	GetChecker(tc).Test(t, http.MethodGet, "/resource/1/rating").
 		WithHeader("Authorization", accessToken).Check().
 		HasStatus(403).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -129,7 +129,7 @@ func TestGet_Http(t *testing.T) {
 	GetChecker(tc).Test(t, http.MethodGet, "/resource/1/rating").
 		WithHeader("Authorization", accessToken).Check().
 		HasStatus(200).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -156,7 +156,7 @@ func TestGet_Http_RatingNotFound(t *testing.T) {
 	GetChecker(tc).Test(t, http.MethodGet, "/resource/3/rating").
 		WithHeader("Authorization", accessToken).Check().
 		HasStatus(200).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -183,7 +183,7 @@ func TestGet_Http_ResourceNotFound(t *testing.T) {
 	GetChecker(tc).Test(t, http.MethodGet, "/resource/99/rating").
 		WithHeader("Authorization", accessToken).Check().
 		HasStatus(404).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -273,7 +273,7 @@ func TestUpdate_Http_ResourceNotFound(t *testing.T) {
 		WithHeader("Authorization", accessToken).
 		WithBody(data).Check().
 		HasStatus(404).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 

--- a/api/pkg/service/status/status_http_test.go
+++ b/api/pkg/service/status/status_http_test.go
@@ -17,7 +17,7 @@ package status
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"testing"
@@ -92,7 +92,7 @@ func TestOk_http(t *testing.T) {
 
 	checker.Test(t, http.MethodGet, "/").Check().
 		HasStatus(http.StatusOK).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -120,7 +120,7 @@ func TestDB_NotOK(t *testing.T) {
 
 	checker.Test(t, http.MethodGet, "/").Check().
 		HasStatus(http.StatusOK).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 

--- a/api/v1/gen/catalog/client.go
+++ b/api/v1/gen/catalog/client.go
@@ -27,8 +27,8 @@ func NewClient(list goa.Endpoint) *Client {
 
 // List calls the "List" endpoint of the "catalog" service.
 // List may return the following errors:
-//	- "internal-error" (type *goa.ServiceError): Internal Server Error
-//	- error: internal error
+//   - "internal-error" (type *goa.ServiceError): Internal Server Error
+//   - error: internal error
 func (c *Client) List(ctx context.Context) (res *ListResult, err error) {
 	var ires interface{}
 	ires, err = c.ListEndpoint(ctx, nil)

--- a/api/v1/gen/http/catalog/client/encode_decode.go
+++ b/api/v1/gen/http/catalog/client/encode_decode.go
@@ -37,8 +37,8 @@ func (c *Client) BuildListRequest(ctx context.Context, v interface{}) (*http.Req
 // List endpoint. restoreBody controls whether the response body should be
 // restored after having been read.
 // DecodeListResponse may return the following errors:
-//	- "internal-error" (type *goa.ServiceError): http.StatusInternalServerError
-//	- error: internal error
+//   - "internal-error" (type *goa.ServiceError): http.StatusInternalServerError
+//   - error: internal error
 func DecodeListResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
 	return func(resp *http.Response) (interface{}, error) {
 		if restoreBody {

--- a/api/v1/gen/http/cli/hub/cli.go
+++ b/api/v1/gen/http/cli/hub/cli.go
@@ -21,8 +21,7 @@ import (
 
 // UsageCommands returns the set of commands and sub-commands using the format
 //
-//    command (subcommand1|subcommand2|...)
-//
+//	command (subcommand1|subcommand2|...)
 func UsageCommands() string {
 	return `catalog list
 resource (query|list|versions-by-id|by-catalog-kind-name-version|by-catalog-kind-name-version-readme|by-catalog-kind-name-version-yaml|by-version-id|by-catalog-kind-name|by-id|get-raw-yaml-by-catalog-kind-name-version)

--- a/api/v1/gen/http/resource/client/encode_decode.go
+++ b/api/v1/gen/http/resource/client/encode_decode.go
@@ -71,10 +71,10 @@ func EncodeQueryRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.
 // Query endpoint. restoreBody controls whether the response body should be
 // restored after having been read.
 // DecodeQueryResponse may return the following errors:
-//	- "internal-error" (type *goa.ServiceError): http.StatusInternalServerError
-//	- "invalid-kind" (type *goa.ServiceError): http.StatusBadRequest
-//	- "not-found" (type *goa.ServiceError): http.StatusNotFound
-//	- error: internal error
+//   - "internal-error" (type *goa.ServiceError): http.StatusInternalServerError
+//   - "invalid-kind" (type *goa.ServiceError): http.StatusBadRequest
+//   - "not-found" (type *goa.ServiceError): http.StatusNotFound
+//   - error: internal error
 func DecodeQueryResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
 	return func(resp *http.Response) (interface{}, error) {
 		if restoreBody {
@@ -190,9 +190,9 @@ func EncodeListRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.R
 // List endpoint. restoreBody controls whether the response body should be
 // restored after having been read.
 // DecodeListResponse may return the following errors:
-//	- "internal-error" (type *goa.ServiceError): http.StatusInternalServerError
-//	- "not-found" (type *goa.ServiceError): http.StatusNotFound
-//	- error: internal error
+//   - "internal-error" (type *goa.ServiceError): http.StatusInternalServerError
+//   - "not-found" (type *goa.ServiceError): http.StatusNotFound
+//   - error: internal error
 func DecodeListResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
 	return func(resp *http.Response) (interface{}, error) {
 		if restoreBody {
@@ -289,9 +289,9 @@ func (c *Client) BuildVersionsByIDRequest(ctx context.Context, v interface{}) (*
 // resource VersionsByID endpoint. restoreBody controls whether the response
 // body should be restored after having been read.
 // DecodeVersionsByIDResponse may return the following errors:
-//	- "internal-error" (type *goa.ServiceError): http.StatusInternalServerError
-//	- "not-found" (type *goa.ServiceError): http.StatusNotFound
-//	- error: internal error
+//   - "internal-error" (type *goa.ServiceError): http.StatusInternalServerError
+//   - "not-found" (type *goa.ServiceError): http.StatusNotFound
+//   - error: internal error
 func DecodeVersionsByIDResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
 	return func(resp *http.Response) (interface{}, error) {
 		if restoreBody {
@@ -395,9 +395,9 @@ func (c *Client) BuildByCatalogKindNameVersionRequest(ctx context.Context, v int
 // returned by the resource ByCatalogKindNameVersion endpoint. restoreBody
 // controls whether the response body should be restored after having been read.
 // DecodeByCatalogKindNameVersionResponse may return the following errors:
-//	- "internal-error" (type *goa.ServiceError): http.StatusInternalServerError
-//	- "not-found" (type *goa.ServiceError): http.StatusNotFound
-//	- error: internal error
+//   - "internal-error" (type *goa.ServiceError): http.StatusInternalServerError
+//   - "not-found" (type *goa.ServiceError): http.StatusNotFound
+//   - error: internal error
 func DecodeByCatalogKindNameVersionResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
 	return func(resp *http.Response) (interface{}, error) {
 		if restoreBody {
@@ -502,9 +502,9 @@ func (c *Client) BuildByCatalogKindNameVersionReadmeRequest(ctx context.Context,
 // restoreBody controls whether the response body should be restored after
 // having been read.
 // DecodeByCatalogKindNameVersionReadmeResponse may return the following errors:
-//	- "internal-error" (type *goa.ServiceError): http.StatusInternalServerError
-//	- "not-found" (type *goa.ServiceError): http.StatusNotFound
-//	- error: internal error
+//   - "internal-error" (type *goa.ServiceError): http.StatusInternalServerError
+//   - "not-found" (type *goa.ServiceError): http.StatusNotFound
+//   - error: internal error
 func DecodeByCatalogKindNameVersionReadmeResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
 	return func(resp *http.Response) (interface{}, error) {
 		if restoreBody {
@@ -608,9 +608,9 @@ func (c *Client) BuildByCatalogKindNameVersionYamlRequest(ctx context.Context, v
 // returned by the resource ByCatalogKindNameVersionYaml endpoint. restoreBody
 // controls whether the response body should be restored after having been read.
 // DecodeByCatalogKindNameVersionYamlResponse may return the following errors:
-//	- "internal-error" (type *goa.ServiceError): http.StatusInternalServerError
-//	- "not-found" (type *goa.ServiceError): http.StatusNotFound
-//	- error: internal error
+//   - "internal-error" (type *goa.ServiceError): http.StatusInternalServerError
+//   - "not-found" (type *goa.ServiceError): http.StatusNotFound
+//   - error: internal error
 func DecodeByCatalogKindNameVersionYamlResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
 	return func(resp *http.Response) (interface{}, error) {
 		if restoreBody {
@@ -707,9 +707,9 @@ func (c *Client) BuildByVersionIDRequest(ctx context.Context, v interface{}) (*h
 // resource ByVersionId endpoint. restoreBody controls whether the response
 // body should be restored after having been read.
 // DecodeByVersionIDResponse may return the following errors:
-//	- "internal-error" (type *goa.ServiceError): http.StatusInternalServerError
-//	- "not-found" (type *goa.ServiceError): http.StatusNotFound
-//	- error: internal error
+//   - "internal-error" (type *goa.ServiceError): http.StatusInternalServerError
+//   - "not-found" (type *goa.ServiceError): http.StatusNotFound
+//   - error: internal error
 func DecodeByVersionIDResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
 	return func(resp *http.Response) (interface{}, error) {
 		if restoreBody {
@@ -827,9 +827,9 @@ func EncodeByCatalogKindNameRequest(encoder func(*http.Request) goahttp.Encoder)
 // the resource ByCatalogKindName endpoint. restoreBody controls whether the
 // response body should be restored after having been read.
 // DecodeByCatalogKindNameResponse may return the following errors:
-//	- "internal-error" (type *goa.ServiceError): http.StatusInternalServerError
-//	- "not-found" (type *goa.ServiceError): http.StatusNotFound
-//	- error: internal error
+//   - "internal-error" (type *goa.ServiceError): http.StatusInternalServerError
+//   - "not-found" (type *goa.ServiceError): http.StatusNotFound
+//   - error: internal error
 func DecodeByCatalogKindNameResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
 	return func(resp *http.Response) (interface{}, error) {
 		if restoreBody {
@@ -926,9 +926,9 @@ func (c *Client) BuildByIDRequest(ctx context.Context, v interface{}) (*http.Req
 // ById endpoint. restoreBody controls whether the response body should be
 // restored after having been read.
 // DecodeByIDResponse may return the following errors:
-//	- "internal-error" (type *goa.ServiceError): http.StatusInternalServerError
-//	- "not-found" (type *goa.ServiceError): http.StatusNotFound
-//	- error: internal error
+//   - "internal-error" (type *goa.ServiceError): http.StatusInternalServerError
+//   - "not-found" (type *goa.ServiceError): http.StatusNotFound
+//   - error: internal error
 func DecodeByIDResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
 	return func(resp *http.Response) (interface{}, error) {
 		if restoreBody {
@@ -1034,9 +1034,9 @@ func (c *Client) BuildGetRawYamlByCatalogKindNameVersionRequest(ctx context.Cont
 // after having been read.
 // DecodeGetRawYamlByCatalogKindNameVersionResponse may return the following
 // errors:
-//	- "internal-error" (type *goa.ServiceError): http.StatusInternalServerError
-//	- "not-found" (type *goa.ServiceError): http.StatusNotFound
-//	- error: internal error
+//   - "internal-error" (type *goa.ServiceError): http.StatusInternalServerError
+//   - "not-found" (type *goa.ServiceError): http.StatusNotFound
+//   - error: internal error
 func DecodeGetRawYamlByCatalogKindNameVersionResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
 	return func(resp *http.Response) (interface{}, error) {
 		if restoreBody {

--- a/api/v1/gen/resource/client.go
+++ b/api/v1/gen/resource/client.go
@@ -46,10 +46,10 @@ func NewClient(query, list, versionsByID, byCatalogKindNameVersion, byCatalogKin
 
 // Query calls the "Query" endpoint of the "resource" service.
 // Query may return the following errors:
-//	- "internal-error" (type *goa.ServiceError): Internal Server Error
-//	- "not-found" (type *goa.ServiceError): Resource Not Found Error
-//	- "invalid-kind" (type *goa.ServiceError): Invalid Resource Kind
-//	- error: internal error
+//   - "internal-error" (type *goa.ServiceError): Internal Server Error
+//   - "not-found" (type *goa.ServiceError): Resource Not Found Error
+//   - "invalid-kind" (type *goa.ServiceError): Invalid Resource Kind
+//   - error: internal error
 func (c *Client) Query(ctx context.Context, p *QueryPayload) (res *Resources, err error) {
 	var ires interface{}
 	ires, err = c.QueryEndpoint(ctx, p)
@@ -61,10 +61,10 @@ func (c *Client) Query(ctx context.Context, p *QueryPayload) (res *Resources, er
 
 // List calls the "List" endpoint of the "resource" service.
 // List may return the following errors:
-//	- "internal-error" (type *goa.ServiceError): Internal Server Error
-//	- "not-found" (type *goa.ServiceError): Resource Not Found Error
-//	- "invalid-kind" (type *goa.ServiceError): Invalid Resource Kind
-//	- error: internal error
+//   - "internal-error" (type *goa.ServiceError): Internal Server Error
+//   - "not-found" (type *goa.ServiceError): Resource Not Found Error
+//   - "invalid-kind" (type *goa.ServiceError): Invalid Resource Kind
+//   - error: internal error
 func (c *Client) List(ctx context.Context, p *ListPayload) (res *Resources, err error) {
 	var ires interface{}
 	ires, err = c.ListEndpoint(ctx, p)
@@ -76,10 +76,10 @@ func (c *Client) List(ctx context.Context, p *ListPayload) (res *Resources, err 
 
 // VersionsByID calls the "VersionsByID" endpoint of the "resource" service.
 // VersionsByID may return the following errors:
-//	- "internal-error" (type *goa.ServiceError): Internal Server Error
-//	- "not-found" (type *goa.ServiceError): Resource Not Found Error
-//	- "invalid-kind" (type *goa.ServiceError): Invalid Resource Kind
-//	- error: internal error
+//   - "internal-error" (type *goa.ServiceError): Internal Server Error
+//   - "not-found" (type *goa.ServiceError): Resource Not Found Error
+//   - "invalid-kind" (type *goa.ServiceError): Invalid Resource Kind
+//   - error: internal error
 func (c *Client) VersionsByID(ctx context.Context, p *VersionsByIDPayload) (res *ResourceVersions, err error) {
 	var ires interface{}
 	ires, err = c.VersionsByIDEndpoint(ctx, p)
@@ -92,10 +92,10 @@ func (c *Client) VersionsByID(ctx context.Context, p *VersionsByIDPayload) (res 
 // ByCatalogKindNameVersion calls the "ByCatalogKindNameVersion" endpoint of
 // the "resource" service.
 // ByCatalogKindNameVersion may return the following errors:
-//	- "internal-error" (type *goa.ServiceError): Internal Server Error
-//	- "not-found" (type *goa.ServiceError): Resource Not Found Error
-//	- "invalid-kind" (type *goa.ServiceError): Invalid Resource Kind
-//	- error: internal error
+//   - "internal-error" (type *goa.ServiceError): Internal Server Error
+//   - "not-found" (type *goa.ServiceError): Resource Not Found Error
+//   - "invalid-kind" (type *goa.ServiceError): Invalid Resource Kind
+//   - error: internal error
 func (c *Client) ByCatalogKindNameVersion(ctx context.Context, p *ByCatalogKindNameVersionPayload) (res *ResourceVersion, err error) {
 	var ires interface{}
 	ires, err = c.ByCatalogKindNameVersionEndpoint(ctx, p)
@@ -108,10 +108,10 @@ func (c *Client) ByCatalogKindNameVersion(ctx context.Context, p *ByCatalogKindN
 // ByCatalogKindNameVersionReadme calls the "ByCatalogKindNameVersionReadme"
 // endpoint of the "resource" service.
 // ByCatalogKindNameVersionReadme may return the following errors:
-//	- "internal-error" (type *goa.ServiceError): Internal Server Error
-//	- "not-found" (type *goa.ServiceError): Resource Not Found Error
-//	- "invalid-kind" (type *goa.ServiceError): Invalid Resource Kind
-//	- error: internal error
+//   - "internal-error" (type *goa.ServiceError): Internal Server Error
+//   - "not-found" (type *goa.ServiceError): Resource Not Found Error
+//   - "invalid-kind" (type *goa.ServiceError): Invalid Resource Kind
+//   - error: internal error
 func (c *Client) ByCatalogKindNameVersionReadme(ctx context.Context, p *ByCatalogKindNameVersionReadmePayload) (res *ResourceVersionReadme, err error) {
 	var ires interface{}
 	ires, err = c.ByCatalogKindNameVersionReadmeEndpoint(ctx, p)
@@ -124,10 +124,10 @@ func (c *Client) ByCatalogKindNameVersionReadme(ctx context.Context, p *ByCatalo
 // ByCatalogKindNameVersionYaml calls the "ByCatalogKindNameVersionYaml"
 // endpoint of the "resource" service.
 // ByCatalogKindNameVersionYaml may return the following errors:
-//	- "internal-error" (type *goa.ServiceError): Internal Server Error
-//	- "not-found" (type *goa.ServiceError): Resource Not Found Error
-//	- "invalid-kind" (type *goa.ServiceError): Invalid Resource Kind
-//	- error: internal error
+//   - "internal-error" (type *goa.ServiceError): Internal Server Error
+//   - "not-found" (type *goa.ServiceError): Resource Not Found Error
+//   - "invalid-kind" (type *goa.ServiceError): Invalid Resource Kind
+//   - error: internal error
 func (c *Client) ByCatalogKindNameVersionYaml(ctx context.Context, p *ByCatalogKindNameVersionYamlPayload) (res *ResourceVersionYaml, err error) {
 	var ires interface{}
 	ires, err = c.ByCatalogKindNameVersionYamlEndpoint(ctx, p)
@@ -139,10 +139,10 @@ func (c *Client) ByCatalogKindNameVersionYaml(ctx context.Context, p *ByCatalogK
 
 // ByVersionID calls the "ByVersionId" endpoint of the "resource" service.
 // ByVersionID may return the following errors:
-//	- "internal-error" (type *goa.ServiceError): Internal Server Error
-//	- "not-found" (type *goa.ServiceError): Resource Not Found Error
-//	- "invalid-kind" (type *goa.ServiceError): Invalid Resource Kind
-//	- error: internal error
+//   - "internal-error" (type *goa.ServiceError): Internal Server Error
+//   - "not-found" (type *goa.ServiceError): Resource Not Found Error
+//   - "invalid-kind" (type *goa.ServiceError): Invalid Resource Kind
+//   - error: internal error
 func (c *Client) ByVersionID(ctx context.Context, p *ByVersionIDPayload) (res *ResourceVersion, err error) {
 	var ires interface{}
 	ires, err = c.ByVersionIDEndpoint(ctx, p)
@@ -155,10 +155,10 @@ func (c *Client) ByVersionID(ctx context.Context, p *ByVersionIDPayload) (res *R
 // ByCatalogKindName calls the "ByCatalogKindName" endpoint of the "resource"
 // service.
 // ByCatalogKindName may return the following errors:
-//	- "internal-error" (type *goa.ServiceError): Internal Server Error
-//	- "not-found" (type *goa.ServiceError): Resource Not Found Error
-//	- "invalid-kind" (type *goa.ServiceError): Invalid Resource Kind
-//	- error: internal error
+//   - "internal-error" (type *goa.ServiceError): Internal Server Error
+//   - "not-found" (type *goa.ServiceError): Resource Not Found Error
+//   - "invalid-kind" (type *goa.ServiceError): Invalid Resource Kind
+//   - error: internal error
 func (c *Client) ByCatalogKindName(ctx context.Context, p *ByCatalogKindNamePayload) (res *Resource, err error) {
 	var ires interface{}
 	ires, err = c.ByCatalogKindNameEndpoint(ctx, p)
@@ -170,10 +170,10 @@ func (c *Client) ByCatalogKindName(ctx context.Context, p *ByCatalogKindNamePayl
 
 // ByID calls the "ById" endpoint of the "resource" service.
 // ByID may return the following errors:
-//	- "internal-error" (type *goa.ServiceError): Internal Server Error
-//	- "not-found" (type *goa.ServiceError): Resource Not Found Error
-//	- "invalid-kind" (type *goa.ServiceError): Invalid Resource Kind
-//	- error: internal error
+//   - "internal-error" (type *goa.ServiceError): Internal Server Error
+//   - "not-found" (type *goa.ServiceError): Resource Not Found Error
+//   - "invalid-kind" (type *goa.ServiceError): Invalid Resource Kind
+//   - error: internal error
 func (c *Client) ByID(ctx context.Context, p *ByIDPayload) (res *Resource, err error) {
 	var ires interface{}
 	ires, err = c.ByIDEndpoint(ctx, p)
@@ -186,10 +186,10 @@ func (c *Client) ByID(ctx context.Context, p *ByIDPayload) (res *Resource, err e
 // GetRawYamlByCatalogKindNameVersion calls the
 // "GetRawYamlByCatalogKindNameVersion" endpoint of the "resource" service.
 // GetRawYamlByCatalogKindNameVersion may return the following errors:
-//	- "internal-error" (type *goa.ServiceError): Internal Server Error
-//	- "not-found" (type *goa.ServiceError): Resource Not Found Error
-//	- "invalid-kind" (type *goa.ServiceError): Invalid Resource Kind
-//	- error: internal error
+//   - "internal-error" (type *goa.ServiceError): Internal Server Error
+//   - "not-found" (type *goa.ServiceError): Resource Not Found Error
+//   - "invalid-kind" (type *goa.ServiceError): Invalid Resource Kind
+//   - error: internal error
 func (c *Client) GetRawYamlByCatalogKindNameVersion(ctx context.Context, p *GetRawYamlByCatalogKindNameVersionPayload) (resp io.ReadCloser, err error) {
 	var ires interface{}
 	ires, err = c.GetRawYamlByCatalogKindNameVersionEndpoint(ctx, p)

--- a/api/v1/service/catalog/catalog_http_test.go
+++ b/api/v1/service/catalog/catalog_http_test.go
@@ -16,7 +16,7 @@ package catalog
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -40,7 +40,7 @@ func TestCatalog_List_Http(t *testing.T) {
 
 	checker.Test(t, http.MethodGet, "/v1/catalogs").Check().
 		HasStatus(http.StatusOK).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 

--- a/api/v1/service/resource/resource.go
+++ b/api/v1/service/resource/resource.go
@@ -19,8 +19,8 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -185,7 +185,7 @@ func (s *service) ByCatalogKindNameVersionReadme(ctx context.Context,
 
 	readmePath := fmt.Sprintf("%s/%s/%s/%s/%s/README.md", s.CatalogClonePath(), strings.ToLower(p.Catalog), strings.ToLower(p.Kind), p.Name, p.Version)
 	s.Logger(ctx).Info(fmt.Sprintf("Fetching README for resource %s", p.Name))
-	content, err := ioutil.ReadFile(readmePath)
+	content, err := os.ReadFile(readmePath)
 	if err != nil {
 		return nil, resource.MakeNotFound(fmt.Errorf("resource not found"))
 	}
@@ -207,7 +207,7 @@ func (s *service) ByCatalogKindNameVersionYaml(ctx context.Context,
 	yamlPath := fmt.Sprintf("%s/%s/%s/%s/%s", s.CatalogClonePath(), strings.ToLower(p.Catalog), strings.ToLower(p.Kind), p.Name, p.Version)
 	yamlPath = fmt.Sprintf("%s/%s.yaml", yamlPath, p.Name)
 	s.Logger(ctx).Info(fmt.Sprintf("Fetching YAML for resource %s", p.Name))
-	content, err := ioutil.ReadFile(yamlPath)
+	content, err := os.ReadFile(yamlPath)
 	if err != nil {
 		return nil, resource.MakeNotFound(fmt.Errorf("resource not found"))
 	}
@@ -511,10 +511,10 @@ func (s *service) GetRawYamlByCatalogKindNameVersion(ctx context.Context, p *res
 	yamlPath := fmt.Sprintf("%s/%s/%s/%s/%s", s.CatalogClonePath(), strings.ToLower(p.Catalog), strings.ToLower(p.Kind), p.Name, p.Version)
 	yamlPath = fmt.Sprintf("%s/%s.yaml", yamlPath, p.Name)
 
-	content, err := ioutil.ReadFile(yamlPath)
+	content, err := os.ReadFile(yamlPath)
 	if err != nil {
 		return nil, resource.MakeNotFound(fmt.Errorf("resource not found"))
 	}
 
-	return ioutil.NopCloser(bytes.NewBuffer(content)), nil
+	return io.NopCloser(bytes.NewBuffer(content)), nil
 }

--- a/api/v1/service/resource/resource_http_test.go
+++ b/api/v1/service/resource/resource_http_test.go
@@ -17,7 +17,7 @@ package resource
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"testing"
@@ -46,7 +46,7 @@ func TestQuery_Http(t *testing.T) {
 
 	QueryChecker(tc).Test(t, http.MethodGet, "/v1/query?name=build&kinds=pipeline&limit=1").Check().
 		HasStatus(200).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -63,7 +63,7 @@ func TestQueryWithKinds_Http(t *testing.T) {
 
 	QueryChecker(tc).Test(t, http.MethodGet, "/v1/query?kinds=pipeline").Check().
 		HasStatus(200).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -80,7 +80,7 @@ func TestQueryWithInvalidKind_Http(t *testing.T) {
 
 	QueryChecker(tc).Test(t, http.MethodGet, "/v1/query?kinds=task&kinds=abc").Check().
 		HasStatus(400).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -99,7 +99,7 @@ func TestQueryWithTags_Http(t *testing.T) {
 
 	QueryChecker(tc).Test(t, http.MethodGet, "/v1/query?tags=ztag&tags=Atag").Check().
 		HasStatus(200).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -116,7 +116,7 @@ func TestQueryWithPlatforms_Http(t *testing.T) {
 
 	QueryChecker(tc).Test(t, http.MethodGet, "/v1/query?platforms=linux/s390x&platforms=linux/amd64").Check().
 		HasStatus(200).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -133,7 +133,7 @@ func TestQueryWithExactName_Http(t *testing.T) {
 
 	QueryChecker(tc).Test(t, http.MethodGet, "/v1/query?name=buildah&exact=true").Check().
 		HasStatus(200).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -150,7 +150,7 @@ func TestQueryWithNameAndKinds_Http(t *testing.T) {
 
 	QueryChecker(tc).Test(t, http.MethodGet, "/v1/query?name=build&kinds=task&kinds=pipeline").Check().
 		HasStatus(200).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -167,7 +167,7 @@ func TestQueryWithNameAndTags_Http(t *testing.T) {
 
 	QueryChecker(tc).Test(t, http.MethodGet, "/v1/query?name=build&tags=atag&tags=ztag").Check().
 		HasStatus(200).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -184,7 +184,7 @@ func TestQueryWithKindsAndTags_Http(t *testing.T) {
 
 	QueryChecker(tc).Test(t, http.MethodGet, "/v1/query?name=build&kinds=task&kinds=pipeline").Check().
 		HasStatus(200).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -201,7 +201,7 @@ func TestQueryWithAllParams_Http(t *testing.T) {
 
 	QueryChecker(tc).Test(t, http.MethodGet, "/v1/query?name=build&kinds=task&kinds=Pipeline&categories=abc&tags=ztag&tags=Atag&exact=false").Check().
 		HasStatus(200).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -218,7 +218,7 @@ func TestQueryWithCategories_Http(t *testing.T) {
 
 	QueryChecker(tc).Test(t, http.MethodGet, "/v1/query?categories=abc").Check().
 		HasStatus(200).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -235,7 +235,7 @@ func TestQueryWithCategoriesAndName_Http(t *testing.T) {
 
 	QueryChecker(tc).Test(t, http.MethodGet, "/v1/query?name=build&categories=abc").Check().
 		HasStatus(200).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -252,7 +252,7 @@ func TestQueryWithCategoriesAndTags_Http(t *testing.T) {
 
 	QueryChecker(tc).Test(t, http.MethodGet, "/v1/query?categories=abc&tags=ztag&tags=Atag").Check().
 		HasStatus(200).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -269,7 +269,7 @@ func TestQueryWithCategoriesAndKinds_Http(t *testing.T) {
 
 	QueryChecker(tc).Test(t, http.MethodGet, "/v1/query?categories=abc&kinds=Pipeline").Check().
 		HasStatus(200).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -286,7 +286,7 @@ func TestQuery_Http_ErrorCase(t *testing.T) {
 
 	QueryChecker(tc).Test(t, http.MethodGet, "/v1/query?name=foo").Check().
 		HasStatus(404).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -312,7 +312,7 @@ func TestList_Http_WithLimit(t *testing.T) {
 
 	ListChecker(tc).Test(t, http.MethodGet, "/v1/resources?limit=2").Check().
 		HasStatus(200).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -330,7 +330,7 @@ func TestList_Http_NoLimit(t *testing.T) {
 
 	ListChecker(tc).Test(t, http.MethodGet, "/v1/resources").Check().
 		HasStatus(200).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -356,7 +356,7 @@ func TestVersionsByID_Http(t *testing.T) {
 
 	VersionsByIDChecker(tc).Test(t, http.MethodGet, "/v1/resource/1/versions").Check().
 		HasStatus(200).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -373,7 +373,7 @@ func TestVersionsByID_Http_ErrorCase(t *testing.T) {
 
 	VersionsByIDChecker(tc).Test(t, http.MethodGet, "/v1/resource/111/versions").Check().
 		HasStatus(404).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -400,7 +400,7 @@ func TestByCatalogKindNameVersion_Http(t *testing.T) {
 
 	ByCatalogKindNameVersionChecker(tc).Test(t, http.MethodGet, "/v1/resource/catalog-official/task/tkn/0.1").Check().
 		HasStatus(200).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -417,7 +417,7 @@ func TestByCatalogKindNameVersion_Http_ErrorCase(t *testing.T) {
 
 	ByCatalogKindNameVersionChecker(tc).Test(t, http.MethodGet, "/v1/resource/catalog-official/task/foo/0.1.1").Check().
 		HasStatus(404).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -447,7 +447,7 @@ func TestByCatalogKindNameVersionReadme_Http(t *testing.T) {
 
 	ByCatalogKindNameVersionReadmeChecker(tc).Test(t, http.MethodGet, "/v1/resource/catalog-official/task/tkn/0.1/readme").Check().
 		HasStatus(200).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -464,7 +464,7 @@ func TestByCatalogKindNameVersionReadme_Http_ErrorCase(t *testing.T) {
 
 	ByCatalogKindNameVersionReadmeChecker(tc).Test(t, http.MethodGet, "/v1/resource/catalog-official/task/foo/0.1.1/readme").Check().
 		HasStatus(404).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -494,7 +494,7 @@ func TestByCatalogKindNameVersionYaml_Http(t *testing.T) {
 
 	ByCatalogKindNameVersionYamlChecker(tc).Test(t, http.MethodGet, "/v1/resource/catalog-official/task/tkn/0.1/yaml").Check().
 		HasStatus(200).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -511,7 +511,7 @@ func TestByCatalogKindNameVersionYaml_Http_ErrorCase(t *testing.T) {
 
 	ByCatalogKindNameVersionYamlChecker(tc).Test(t, http.MethodGet, "/v1/resource/catalog-official/task/foo/0.1.1/yaml").Check().
 		HasStatus(404).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -538,7 +538,7 @@ func TestByVersionID_Http(t *testing.T) {
 
 	ByVersionIDChecker(tc).Test(t, http.MethodGet, "/v1/resource/version/4").Check().
 		HasStatus(200).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -555,7 +555,7 @@ func TestByVersionID_Http_ErrorCase(t *testing.T) {
 
 	ByVersionIDChecker(tc).Test(t, http.MethodGet, "/v1/resource/version/43").Check().
 		HasStatus(404).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -582,7 +582,7 @@ func TestByCatalogKindName_Http(t *testing.T) {
 
 	ByCatalogKindNameChecker(tc).Test(t, http.MethodGet, "/v1/resource/catalog-official/task/tekton").Check().
 		HasStatus(200).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -599,7 +599,7 @@ func TestByEnterpriseCatalogKindName_Http(t *testing.T) {
 
 	ByCatalogKindNameChecker(tc).Test(t, http.MethodGet, "/v1/resource/catalog-enterprise/task/tkn-enterprise").Check().
 		HasStatus(200).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -616,7 +616,7 @@ func TestByCatalogKindName_CompatibleVersion_Http(t *testing.T) {
 
 	ByCatalogKindNameChecker(tc).Test(t, http.MethodGet, "/v1/resource/catalog-official/task/tekton?pipelinesversion=0.12.3").Check().
 		HasStatus(200).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -633,7 +633,7 @@ func TestByCatalogKindName_InvalidPipelinesVersion_Http(t *testing.T) {
 
 	ByCatalogKindNameChecker(tc).Test(t, http.MethodGet, "/v1/resource/catalog-official/task/tekton?pipelinesversion=asd").Check().
 		HasStatus(400).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -651,7 +651,7 @@ func TestByCatalogKindName_InvalidPipelinesVersion_Error_Http(t *testing.T) {
 
 	ByCatalogKindNameChecker(tc).Test(t, http.MethodGet, "/v1/resource/catalog-official/task/tekton?pipelinesversion=v0.12.3").Check().
 		HasStatus(400).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -669,7 +669,7 @@ func TestByCatalogKindName_ValidPipelinesVersion_Http(t *testing.T) {
 
 	ByCatalogKindNameChecker(tc).Test(t, http.MethodGet, "/v1/resource/catalog-official/task/tekton?pipelinesversion=0.13").Check().
 		HasStatus(200).Cb(func(r *http.Response) {
-		_, readErr := ioutil.ReadAll(r.Body)
+		_, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 	})
@@ -681,7 +681,7 @@ func TestByCatalogKindName_NoCompatibleVersion_Http_ErrorCase(t *testing.T) {
 
 	ByCatalogKindNameChecker(tc).Test(t, http.MethodGet, "/v1/resource/catalog-official/task/tekton?pipelinesversion=0.11.0").Check().
 		HasStatus(404).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -699,7 +699,7 @@ func TestByCatalogKindName_Http_ErrorCase(t *testing.T) {
 
 	ByCatalogKindNameChecker(tc).Test(t, http.MethodGet, "/v1/resource/catalog-official/task/foo").Check().
 		HasStatus(404).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -726,7 +726,7 @@ func TestByID_Http(t *testing.T) {
 
 	ByIDChecker(tc).Test(t, http.MethodGet, "/v1/resource/1").Check().
 		HasStatus(200).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -743,7 +743,7 @@ func TestByID_Http_ErrorCase(t *testing.T) {
 
 	ByIDChecker(tc).Test(t, http.MethodGet, "/v1/resource/77").Check().
 		HasStatus(404).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -761,7 +761,7 @@ func TestDeprecationByVersionID_Http(t *testing.T) {
 
 	ByVersionIDChecker(tc).Test(t, http.MethodGet, "/v1/resource/version/10").Check().
 		HasStatus(200).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -778,7 +778,7 @@ func TestLatestVersionDeprecationByID_Http(t *testing.T) {
 
 	ByIDChecker(tc).Test(t, http.MethodGet, "/v1/resource/7").Check().
 		HasStatus(200).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 
@@ -798,7 +798,7 @@ func TestGetYamlByCatalogKindNameVersion_Http(t *testing.T) {
 
 	GetYamlByCatalogKindNameVersion_Checker(tc).Test(t, http.MethodGet, "/v1/resource/catalog-official/task/tkn/0.1/raw").Check().
 		HasStatus(200).Cb(func(r *http.Response) {
-		b, readErr := ioutil.ReadAll(r.Body)
+		b, readErr := io.ReadAll(r.Body)
 		assert.NoError(t, readErr)
 		defer r.Body.Close()
 

--- a/ui/src/components/Background/Background.test.tsx
+++ b/ui/src/components/Background/Background.test.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { shallow } from 'enzyme';
 import Background from '.';
 

--- a/ui/src/components/Footer/Footer.test.tsx
+++ b/ui/src/components/Footer/Footer.test.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { shallow } from 'enzyme';
 import Footer from '.';
 import { FakeDate, ActualDate } from '../../common/testutils';

--- a/ui/src/containers/Search/Search.test.tsx
+++ b/ui/src/containers/Search/Search.test.tsx
@@ -1,5 +1,4 @@
-import { ReactComponent } from '*.svg';
-import { FormSelectOption, TextInput } from '@patternfly/react-core';
+import { TextInput } from '@patternfly/react-core';
 import { mount, shallow } from 'enzyme';
 import { when } from 'mobx';
 import React from 'react';


### PR DESCRIPTION
- Api build test for api was failing
 due to go package bump in plumbing (https://github.com/tektoncd/plumbing/pull/1369)
- This patch also fixes lint errors in api and ui and updates go version in goa-gen dependabot

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [x] Run API Unit Tests, Lint Checks, API Design, Golden Files with `make api-check`
- [ ] Run UI Unit Tests, Lint Checks with `make ui-check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->