### PR TITLE
 Fixes Hub API to support `v1` api's of Tekton Resource

### DIFF
--- a/api/pkg/parser/catalog.go
+++ b/api/pkg/parser/catalog.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/tektoncd/hub/api/pkg/git"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -428,5 +429,5 @@ func typeForKind(kind string) (tektonKind, error) {
 
 func isTektonKind(gvk *schema.GroupVersionKind) bool {
 	id := gvk.GroupVersion().Identifier()
-	return id == v1beta1.SchemeGroupVersion.Identifier()
+	return id == v1beta1.SchemeGroupVersion.Identifier() || id == v1.SchemeGroupVersion.Identifier()
 }

--- a/api/pkg/parser/parser.go
+++ b/api/pkg/parser/parser.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 
 	"github.com/tektoncd/hub/api/pkg/git"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -30,8 +31,8 @@ type Parser interface {
 }
 
 func registerSchema() {
-	beta1 := runtime.NewSchemeBuilder(v1beta1.AddToScheme)
-	if err := beta1.AddToScheme(scheme.Scheme); err != nil {
+	tektonSchemes := runtime.NewSchemeBuilder(v1beta1.AddToScheme, v1.AddToScheme)
+	if err := tektonSchemes.AddToScheme(scheme.Scheme); err != nil {
 		fmt.Printf("Failed to apply all stored functions to the scheme %v", err)
 	}
 }


### PR DESCRIPTION
- Initially only `v1beta1` tekton resources were parsed and
added in the database, but with latest release of tekton
piplines this patch now supports `v1` api of Tekton resources

Signed-off-by: Puneet Punamiya ppunamiy@redhat.com

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Run API Unit Tests, Lint Checks, API Design, Golden Files with `make api-check`
- [ ] Run UI Unit Tests, Lint Checks with `make ui-check`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->