### PR TITLE
Remove lower case conversion of catalog name

### DIFF
--- a/api/v1/service/resource/resource.go
+++ b/api/v1/service/resource/resource.go
@@ -183,7 +183,7 @@ func (s *service) ByCatalogKindNameVersion(ctx context.Context, p *resource.ByCa
 func (s *service) ByCatalogKindNameVersionReadme(ctx context.Context,
 	p *resource.ByCatalogKindNameVersionReadmePayload) (*resource.ResourceVersionReadme, error) {
 
-	readmePath := fmt.Sprintf("%s/%s/%s/%s/%s/README.md", s.CatalogClonePath(), strings.ToLower(p.Catalog), strings.ToLower(p.Kind), p.Name, p.Version)
+	readmePath := fmt.Sprintf("%s/%s/%s/%s/%s/README.md", s.CatalogClonePath(), p.Catalog, strings.ToLower(p.Kind), p.Name, p.Version)
 	s.Logger(ctx).Info(fmt.Sprintf("Fetching README for resource %s", p.Name))
 	content, err := os.ReadFile(readmePath)
 	if err != nil {
@@ -204,7 +204,7 @@ func (s *service) ByCatalogKindNameVersionReadme(ctx context.Context,
 func (s *service) ByCatalogKindNameVersionYaml(ctx context.Context,
 	p *resource.ByCatalogKindNameVersionYamlPayload) (*resource.ResourceVersionYaml, error) {
 
-	yamlPath := fmt.Sprintf("%s/%s/%s/%s/%s", s.CatalogClonePath(), strings.ToLower(p.Catalog), strings.ToLower(p.Kind), p.Name, p.Version)
+	yamlPath := fmt.Sprintf("%s/%s/%s/%s/%s", s.CatalogClonePath(), p.Catalog, p.Kind, p.Name, p.Version)
 	yamlPath = fmt.Sprintf("%s/%s.yaml", yamlPath, p.Name)
 	s.Logger(ctx).Info(fmt.Sprintf("Fetching YAML for resource %s", p.Name))
 	content, err := os.ReadFile(yamlPath)
@@ -508,7 +508,7 @@ func versionInfoFromVersion(v model.ResourceVersion) *resource.ResourceVersion {
 func (s *service) GetRawYamlByCatalogKindNameVersion(ctx context.Context, p *resource.GetRawYamlByCatalogKindNameVersionPayload) (io.ReadCloser, error) {
 	s.Logger(ctx).Info(fmt.Sprintf("Fetching YAML for resource %s", p.Name))
 
-	yamlPath := fmt.Sprintf("%s/%s/%s/%s/%s", s.CatalogClonePath(), strings.ToLower(p.Catalog), strings.ToLower(p.Kind), p.Name, p.Version)
+	yamlPath := fmt.Sprintf("%s/%s/%s/%s/%s", s.CatalogClonePath(), p.Catalog, strings.ToLower(p.Kind), p.Name, p.Version)
 	yamlPath = fmt.Sprintf("%s/%s.yaml", yamlPath, p.Name)
 
 	content, err := os.ReadFile(yamlPath)


### PR DESCRIPTION
If catalog name is MyCatalg then clone path would be `tmp/catalog/MyCatalog` and file path generation was wrong due to lower conversion

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Run API Unit Tests, Lint Checks, API Design, Golden Files with `make api-check`
- [ ] Run UI Unit Tests, Lint Checks with `make ui-check`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->