### PR TITLE
Add `.golangci.yaml` file to ignore cluster task deprecation warning

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,9 @@
+run:
+  issues-exit-code: 1
+  skip-dirs:
+    - vendor
+linters-settings:
+  staticcheck:
+    checks:
+      - '-SA1019' # ignore ClusterTask warning
+

--- a/api/pkg/parser/catalog.go
+++ b/api/pkg/parser/catalog.go
@@ -418,6 +418,7 @@ func typeForKind(kind string) (tektonKind, error) {
 	switch kind {
 	case "Task":
 		return &v1beta1.Task{}, nil
+	// ClusterTasks are deprecated in Pipeline 0.44.0 and will be removed in future releases
 	case "ClusterTask":
 		return &v1beta1.ClusterTask{}, nil
 	case "Pipeline":


### PR DESCRIPTION
This patch will add .golangci.yml file to add
rule to skip cluster task deprecation warning during 
api lint check as in pipeline 0.44. it is deprecated and support
for cluster task will be removed in future releases
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Run API Unit Tests, Lint Checks, API Design, Golden Files with `make api-check`
- [ ] Run UI Unit Tests, Lint Checks with `make ui-check`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
This will add `.golangci.yaml` file to add a rule to skip deprecation warning during api lint check
```