### PR TITLE
Fixes Hub CI by bumping postgres to postgres 15 and node to 18.x

### DIFF
--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -57,10 +57,13 @@ err() {
 install-node() {
   info Installing node
 
-  curl -sL https://deb.nodesource.com/setup_17.x | bash -
+  curl -sL https://deb.nodesource.com/setup_18.x | bash -
   apt-get install -y nodejs
 
   node --version
+
+  apt-get install -y npm
+  npm --version
 }
 
 ui-unittest() {
@@ -78,9 +81,9 @@ install-postgres() {
   wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
   sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" >> /etc/apt/sources.list.d/pgdg.list'
   apt-get update
-  apt-get -y install postgresql-13
+  apt-get -y install postgresql-15
   service postgresql start
-  pg_ctlcluster 13 main start
+  pg_ctlcluster 15 main start
 }
 
 set-pg-passwd() {


### PR DESCRIPTION
- With the base image of ubuntu bumped in plumbing CI,
postgres was not getting installed, hence this patch
bumps the postgres version in Hub CI to as the new
version of ubuntu supports postgres 15 and above

- Also in this patch node version is bumped to 18.x

Signed-off-by: Puneet Punamiya ppunamiy@redhat.com

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Run API Unit Tests, Lint Checks, API Design, Golden Files with `make api-check`
- [ ] Run UI Unit Tests, Lint Checks with `make ui-check`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->