### PR TITLE
Set the CookieStore key in Auth API Server

### DIFF
--- a/api/pkg/auth/base.go
+++ b/api/pkg/auth/base.go
@@ -15,6 +15,8 @@
 package auth
 
 import (
+	"crypto/rand"
+	"encoding/base64"
 	"net/http"
 	"os"
 	"strings"
@@ -31,11 +33,25 @@ import (
 	auth "github.com/tektoncd/hub/api/pkg/auth/service"
 )
 
+// generateRandomKey return a random generated key
+func generateRandomKey(length int) (string, error) {
+	key := make([]byte, length)
+	_, err := rand.Read(key)
+	if err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(key), nil
+}
+
 // Auth Provider provides routes for authentication
 // and also defines git providers using goth
 func AuthProvider(r *mux.Router, api app.Config) {
 
-	key := ""            // Replace with your SESSION_SECRET or similar
+	key, err := generateRandomKey(32)
+	if err != nil {
+		panic(err)
+	}
+
 	maxAge := 86400 * 30 // 30 days
 	isProd := true       // Set to false when not serving over https
 	if api.Environment() != app.EnvMode("production") {


### PR DESCRIPTION
# Changes

This commit sets CookieStore key to a random string
earlier it was empty and due change in [`gorilla/securecookie` ](https://github.com/gorilla/sessions/pull/240)
package, CookieStore expects to set the key

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Run API Unit Tests, Lint Checks, API Design, Golden Files with `make api-check`
- [ ] Run UI Unit Tests, Lint Checks with `make ui-check`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Set the CookieStore key in Auth API Server to fix login 
```