### PR TITLE
config: set readOnlyRootFilesystem on all containers

### DIFF
--- a/config/01-db/10-db-migration.yaml
+++ b/config/01-db/10-db-migration.yaml
@@ -31,6 +31,7 @@ spec:
           image: quay.io/tekton-hub/db-migration
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             runAsUser: 65532
             capabilities:
               drop:

--- a/config/02-api/22-api-deployment.yaml
+++ b/config/02-api/22-api-deployment.yaml
@@ -95,6 +95,7 @@ spec:
             timeoutSeconds: 1
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             runAsUser: 65532
             capabilities:
               drop:

--- a/config/03-ui/31-ui-deployment.yaml
+++ b/config/03-ui/31-ui-deployment.yaml
@@ -32,6 +32,7 @@ spec:
               memory: 500Mi
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             runAsUser: 65532
             capabilities:
               drop:

--- a/config/06-swagger/00-config/01-swagger-deployment.yaml
+++ b/config/06-swagger/00-config/01-swagger-deployment.yaml
@@ -25,6 +25,7 @@ spec:
           image: quay.io/tekton-hub/swagger
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             runAsUser: 65532
             capabilities:
               drop:


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

`readOnlyRootFilesystem` will keep you from writing anywhere other
than a mounted volume. It's not just the root directory but the entire
root filesystem.

It's a security best practice that we should embrace in all the Tekton
components.

Signed-off-by: Vincent Demeester <vincent@sbr.pm>

/kind security
<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Run API Unit Tests, Lint Checks, API Design, Golden Files with `make api-check`
- [ ] Run UI Unit Tests, Lint Checks with `make ui-check`
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._

# Release Notes


```release-note
All results containers now ship with readOnlyRootFilesystem set to true. It is a security best-practice.
```
